### PR TITLE
Feature: Ability to set single object lookup key

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -118,9 +118,13 @@ def build_filter_kwargs(filters):
     return filter_kwargs, filter_methods
 
 
-def apply(filters, queryset, pk=UNSET):
-    if pk is not UNSET:
-        queryset = queryset.filter(pk=pk)
+def apply(filters, queryset, lookup_key=UNSET, lookup_key_value=UNSET):
+    if lookup_key is UNSET:
+        # When using apply() directly
+        lookup_key = "pk"
+
+    if lookup_key_value is not UNSET:
+        queryset = queryset.filter(**{lookup_key: lookup_key_value})
 
     if (
         filters is UNSET
@@ -142,8 +146,12 @@ def apply(filters, queryset, pk=UNSET):
 
 
 class StrawberryDjangoFieldFilters:
-    def __init__(self, filters=UNSET, **kwargs):
+    def __init__(
+        self, filters=UNSET, lookup_key=UNSET, lookup_key_type=UNSET, **kwargs
+    ):
         self.filters = filters
+        self.lookup_key = lookup_key
+        self.lookup_key_type = lookup_key_type
         super().__init__(**kwargs)
 
     @property
@@ -153,10 +161,38 @@ class StrawberryDjangoFieldFilters:
             filters = self.get_filters()
             if self.django_model and not self.is_list:
                 if self.is_relation is False:
-                    arguments.append(argument("pk", strawberry.ID))
+                    arguments.append(
+                        argument(
+                            self.get_lookup_key(),
+                            self.get_lookup_key_type(),
+                            is_optional=False,
+                        )
+                    )
             elif filters and filters is not UNSET:
                 arguments.append(argument("filters", filters))
         return super().arguments + arguments
+
+    def get_lookup_key(self):
+        if self.lookup_key is not UNSET:
+            return self.lookup_key
+
+        type_ = utils.unwrap_type(self.type or self.child.type)
+        if utils.is_django_type(type_):
+            if type_._django_type.lookup_key is not UNSET:
+                return type_._django_type.lookup_key
+
+        return "pk"
+
+    def get_lookup_key_type(self):
+        if self.lookup_key_type is not UNSET:
+            return self.lookup_key_type
+
+        type_ = utils.unwrap_type(self.type or self.child.type)
+        if utils.is_django_type(type_):
+            if type_._django_type.lookup_key_type is not UNSET:
+                return type_._django_type.lookup_key_type
+
+        return strawberry.ID
 
     def get_filters(self):
         if self.filters is not UNSET:
@@ -167,6 +203,11 @@ class StrawberryDjangoFieldFilters:
             return type_._django_type.filters
         return None
 
-    def get_queryset(self, queryset, info, pk=UNSET, filters=UNSET, **kwargs):
+    def get_queryset(self, queryset, info, filters=UNSET, **kwargs):
         queryset = super().get_queryset(queryset, info, **kwargs)
-        return apply(filters, queryset, pk)
+        lookup_key = self.get_lookup_key()
+        lookup_key_value = kwargs.get(lookup_key, UNSET)
+
+        return apply(
+            filters, queryset, lookup_key=lookup_key, lookup_key_value=lookup_key_value
+        )

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -124,6 +124,8 @@ class StrawberryDjangoType:
     is_partial: bool
     is_filter: bool
     filters: Any
+    lookup_key: Any
+    lookup_key_type: Any
     order: Any
     pagination: Any
     field_cls: StrawberryDjangoFieldType
@@ -134,6 +136,8 @@ def process_type(
     model,
     *,
     filters=UNSET,
+    lookup_key=UNSET,
+    lookup_key_type=UNSET,
     pagination=UNSET,
     order=UNSET,
     field_cls=UNSET,
@@ -151,6 +155,8 @@ def process_type(
         is_partial=kwargs.pop("partial", False),
         is_filter=kwargs.pop("is_filter", False),
         filters=filters,
+        lookup_key=lookup_key,
+        lookup_key_type=lookup_key_type,
         order=order,
         pagination=pagination,
         field_cls=field_cls,

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -125,6 +125,7 @@ class StrawberryDjangoType:
     is_filter: bool
     filters: Any
     lookup_key: Any
+    lookup_key_django_name: Any
     lookup_key_type: Any
     order: Any
     pagination: Any
@@ -137,6 +138,7 @@ def process_type(
     *,
     filters=UNSET,
     lookup_key=UNSET,
+    lookup_key_django_name=UNSET,
     lookup_key_type=UNSET,
     pagination=UNSET,
     order=UNSET,
@@ -156,6 +158,7 @@ def process_type(
         is_filter=kwargs.pop("is_filter", False),
         filters=filters,
         lookup_key=lookup_key,
+        lookup_key_django_name=lookup_key_django_name,
         lookup_key_type=lookup_key_type,
         order=order,
         pagination=pagination,

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -66,6 +66,13 @@ class Fruit:
     name: auto
 
 
+# For demonstrating options set on the type.
+@strawberry_django.type(models.Fruit, lookup_key="name", lookup_key_type=str)
+class FruitNameLookup:
+    id: auto
+    name: auto
+
+
 @strawberry.type
 class Query:
     fruits: List[Fruit] = strawberry_django.field()
@@ -74,7 +81,11 @@ class Query:
     enum_filter: List[Fruit] = strawberry_django.field(filters=EnumFiler)
 
     fruit: Fruit = strawberry_django.field()
+    fruit_id: Fruit = strawberry_django.field(
+        lookup_key="fruit_id", lookup_key_django_name="pk"
+    )
     fruit_named: Fruit = strawberry_django.field(lookup_key="name", lookup_key_type=str)
+    fruit_name_lookup_type: FruitNameLookup = strawberry_django.field()
 
 
 @pytest.fixture
@@ -208,7 +219,19 @@ def test_resolve_by_pk__no_match(query, fruits):
     assert result.errors[0].message == "Fruit matching query does not exist."
 
 
+def test_resolve_by_fruit_id(query, fruits):
+    result = query("{ fruit: fruitId(fruitId: 1) { id name } }")
+    assert not result.errors
+    assert result.data["fruit"] == {"id": "1", "name": "strawberry"}
+
+
 def test_resolve_by_custom_lookup(query, fruits):
     result = query('{ fruit: fruitNamed(name: "strawberry") { id name } }')
+    assert not result.errors
+    assert result.data["fruit"] == {"id": "1", "name": "strawberry"}
+
+
+def test_resolve_by_type_name_lookup(query, fruits):
+    result = query('{ fruit: fruitNameLookupType(name: "strawberry") { id name } }')
     assert not result.errors
     assert result.data["fruit"] == {"id": "1", "name": "strawberry"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
This PR adds the ability to alter the behaviour of a single object lookup. Currently the behaviour is that a single object fetch can only operate on the `pk` of that object (with `pk` as the variable name), but in many cases developers may want to use other names/types.

For maximum flexibility, this PR adds 3 options to the `strawberry.django.field` definition which can be used in many combinations, such as:

```python

@strawberry.type
class Query:
   fruit: Fruit = strawberry.django.field(
      lookup_key="id",
      lookup_key_django_name="uuid",
      lookup_key_type=UUID
   )

```

or

```python

@strawberry.type
class Query:
   fruit: Fruit = strawberry.django.field(
      lookup_key="public_id",
      lookup_key_type=str
   )

```

or

```python

@strawberry.type
class Query:
   fruit: Fruit = strawberry.django.field(
      lookup_key="id",
   )

```

It defaults to the existing behaviour of the lookup field being `pk` and the type being `strawberry.ID`.

The only "breaking" change is that the lookup key is now a required field, so this will slightly alter the generated schema. This can be considered more of a bugfix since the lookups would not work without an argument, other than in the special case where there was only a single record of that type (in which case `.get()` on the queryset _would_ work). I would hope that's not behaviour that anyone is relying on though...  

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

- Closes #107 
- Closes #121 
- Closes #130

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. - **This PR should build on #147 when that's merged**
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
