### PR TITLE
Feature: add new q filter interface

### DIFF
--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -246,7 +246,7 @@ class FruitFilter:
 !!! note
 
     `filter_{field_name}` custom filter not works with `AND`, `OR`, `NOT` nested filters
-    but `q_{field_name}` filter are works
+    but `q_{field_name}` filter is works
 
 ## Overriding the default `filter` method
 

--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -201,6 +201,53 @@ class FruitFilter:
         return queryset
 ```
 
+## Custom filter expressions with Q
+
+You can also define complex custom expression and overriding default filter method with `q_{field_name}` resolver
+
+```{.python title=types.py}
+from django.db.models import Q
+
+@strawberry_django.filter(models.Fruit)
+class FruitFilter:
+    is_banana: bool | None
+
+    def q_is_banana(self, value: bool | None) -> Q:
+        result = Q()
+        if self.is_banana in (None, strawberry.UNSET):
+            return result
+
+        if self.is_banana:
+            result = Q(name="banana")
+        else:
+            result = ~Q(name="banana")
+
+        return result
+```
+
+If you define custom methods `filter_` and `q_` both
+
+only `filter_` works.
+
+!!! note
+
+    `filter_{field_name}` custom filter not works with `AND`, `OR`, `NOT` nested filters
+    but `q_{field_name}` filter are works
+
+```{.python title=types.py}
+@strawberry_django.filter(models.Fruit)
+class FruitFilter:
+    is_banana: bool | None
+
+    # WORK (O)
+    def filter_is_banana(self, queryset) -> QuerySet:
+        return queryset.filter(name="banana")
+
+    # NOT WORK (X)
+    def q_is_banana(self, queryset) -> Q:
+        return Q(name="banana")
+```
+
 ## Overriding the default `filter` method
 
 For overriding the default filter logic you can provide the filter method.

--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -229,11 +229,6 @@ If you define custom methods `filter_` and `q_` both
 
 only `filter_` works.
 
-!!! note
-
-    `filter_{field_name}` custom filter not works with `AND`, `OR`, `NOT` nested filters
-    but `q_{field_name}` filter are works
-
 ```{.python title=types.py}
 @strawberry_django.filter(models.Fruit)
 class FruitFilter:
@@ -247,6 +242,11 @@ class FruitFilter:
     def q_is_banana(self, queryset) -> Q:
         return Q(name="banana")
 ```
+
+!!! note
+
+    `filter_{field_name}` custom filter not works with `AND`, `OR`, `NOT` nested filters
+    but `q_{field_name}` filter are works
 
 ## Overriding the default `filter` method
 

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -217,6 +217,11 @@ def build_filter_kwargs(
             filter_methods.append(filter_method)
             continue
 
+        q_method = getattr(filters, f"q_{'n_' if negated else ''}{field_name}", None)
+        if q_method and (q_value := q_method(field_value)):
+            filter_kwargs &= q_value
+            continue
+
         if django_model:
             if field_name in ("AND", "OR", "NOT"):  # noqa: PLR6201
                 if has_object_definition(field_value):

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -169,7 +169,7 @@ def _resolve_global_id(value: Any):
 
 
 def build_filter_kwargs(
-    filters: WithStrawberryObjectDefinition,
+    filters: Type[WithStrawberryObjectDefinition],
     path="",
 ) -> Tuple[Q, List[Callable]]:
     filter_kwargs = Q()


### PR DESCRIPTION
## Summary
Add new custom filtering Interface
related issue #399 
```
@strawberry_django.filters.filter(models.Fruit)
class QFilter:
    search: Optional[str]

    def q_search(self, value: str) -> Q:
        return Q(name=value)
```

usage.
```
### Fruits = ["strawberry", "raspberry", "banana"]
def test_q_filter_method_with_nested_not_filter(query, fruits):
    result = query(
        '{ fruits: qFilter(filters: { NOT : { search: "strawberry" }}) { id name } }'
    )
    assert result.data["fruits"] == [
        {"id": "2", "name": "raspberry"},
        {"id": "3", "name": "banana"},
    ]
```


## Description
In my project, i implement many custom filters.
Now, custom filters not working with **NOT**, **AND**, **OR**
This change allow user using custom filter with NOT, AND, OR
and user don't have to change custom **filter_{}** method.

Q() style filters are used in other projects also.
https://django-ninja.dev/guides/input/filtering/

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
