### PR TITLE
fix handling of null for lookup filters

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import warnings
 from enum import Enum
 from types import FunctionType
 from typing import (
@@ -251,12 +252,19 @@ def build_filter_kwargs(
             )
             filter_kwargs &= subfield_filter_kwargs
             filter_methods.extend(subfield_filter_methods)
-        elif not is_lookup or (field_value is not UNSET and field_value is not None):
+        elif not is_lookup or field_value is not None:
+            assert field_value is not UNSET, "UNSET should have been filtered before"
             # cannot use in set because field_value can be a list which is unhashable
             filter_kwarg = Q(**{f"{path}{field_name}": field_value})
             if negated:
                 filter_kwarg = ~filter_kwarg
             filter_kwargs &= filter_kwarg
+        elif is_lookup and field_name.endswith("exact"):
+            warnings.warn(
+                "exact can't be used with null anymore, use isnull",
+                DeprecationWarning,
+                stacklevel=1,
+            )
 
     return filter_kwargs, filter_methods
 

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -244,6 +244,15 @@ def build_filter_kwargs(
             ):
                 continue
 
+        if is_lookup and field_name.endswith("exact"):
+            warnings.warn(
+                "exact can't be used with null anymore (will be ignored), use isnull",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+            # a bit hacky but is just for a deprecation
+            is_lookup = False
+
         if has_object_definition(field_value):
             subfield_filter_kwargs, subfield_filter_methods = build_filter_kwargs(
                 cast(WithStrawberryObjectDefinition, field_value),
@@ -259,12 +268,6 @@ def build_filter_kwargs(
             if negated:
                 filter_kwarg = ~filter_kwarg
             filter_kwargs &= filter_kwarg
-        elif is_lookup and field_name.endswith("exact"):
-            warnings.warn(
-                "exact can't be used with null anymore, use isnull",
-                UserWarning,
-                stacklevel=1,
-            )
 
     return filter_kwargs, filter_methods
 

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -253,8 +253,8 @@ def build_filter_kwargs(
             filter_kwargs &= subfield_filter_kwargs
             filter_methods.extend(subfield_filter_methods)
         elif not is_lookup or field_value is not None:
-            assert field_value is not UNSET, "UNSET should have been filtered before"
             # cannot use in set because field_value can be a list which is unhashable
+            assert field_value is not UNSET, "UNSET should have been filtered before"
             filter_kwarg = Q(**{f"{path}{field_name}": field_value})
             if negated:
                 filter_kwarg = ~filter_kwarg

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -262,7 +262,7 @@ def build_filter_kwargs(
         elif is_lookup and field_name.endswith("exact"):
             warnings.warn(
                 "exact can't be used with null anymore, use isnull",
-                DeprecationWarning,
+                UserWarning,
                 stacklevel=1,
             )
 

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -169,8 +169,7 @@ def _resolve_global_id(value: Any):
 
 
 def build_filter_kwargs(
-    filters: WithStrawberryObjectDefinition,
-    path="",
+    filters: WithStrawberryObjectDefinition, path="", is_lookup=False
 ) -> Tuple[Q, List[Callable]]:
     filter_kwargs = Q()
     filter_methods = []
@@ -248,10 +247,12 @@ def build_filter_kwargs(
             subfield_filter_kwargs, subfield_filter_methods = build_filter_kwargs(
                 cast(WithStrawberryObjectDefinition, field_value),
                 f"{path}{field_name}__",
+                is_lookup=isinstance(field_value, FilterLookup),
             )
             filter_kwargs &= subfield_filter_kwargs
             filter_methods.extend(subfield_filter_methods)
-        else:
+        elif not is_lookup or (field_value is not UNSET and field_value is not None):
+            # cannot use in set because field_value can be a list which is unhashable
             filter_kwarg = Q(**{f"{path}{field_name}": field_value})
             if negated:
                 filter_kwarg = ~filter_kwarg

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -150,16 +150,10 @@ def test_without_filtering_by_using_null(query, fruits):
 
 
 def test_using_exact_with_null_triggers_warning(query, fruits):
-    with pytest.warns(UserWarning):
-        result = query(
-            "{ fruits(filters: { name: { exact: null, contains: null } }) { id name } }"
-        )
+    with pytest.warns(DeprecationWarning):
+        result = query("{ fruits(filters: { name: { exact: null } }) { id name } }")
     assert not result.errors
-    assert result.data["fruits"] == [
-        {"id": "1", "name": "strawberry"},
-        {"id": "2", "name": "raspberry"},
-        {"id": "3", "name": "banana"},
-    ]
+    assert result.data["fruits"] == []
 
 
 def test_exact(query, fruits):

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -150,7 +150,7 @@ def test_without_filtering_by_using_null(query, fruits):
 
 
 def test_using_exact_with_null_triggers_warning(query, fruits):
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(UserWarning):
         result = query(
             "{ fruits(filters: { name: { exact: null, contains: null } }) { id name } }"
         )

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -140,9 +140,20 @@ def test_without_filtering(query, fruits):
 
 
 def test_without_filtering_by_using_null(query, fruits):
-    result = query(
-        "{ fruits(filters: { name: { exact: null, contains: null } }) { id name } }"
-    )
+    result = query("{ fruits(filters: { name: { contains: null } }) { id name } }")
+    assert not result.errors
+    assert result.data["fruits"] == [
+        {"id": "1", "name": "strawberry"},
+        {"id": "2", "name": "raspberry"},
+        {"id": "3", "name": "banana"},
+    ]
+
+
+def test_using_exact_with_null_triggers_warning(query, fruits):
+    with pytest.warns(DeprecationWarning):
+        result = query(
+            "{ fruits(filters: { name: { exact: null, contains: null } }) { id name } }"
+        )
     assert not result.errors
     assert result.data["fruits"] == [
         {"id": "1", "name": "strawberry"},

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -139,6 +139,18 @@ def test_without_filtering(query, fruits):
     ]
 
 
+def test_without_filtering_by_using_null(query, fruits):
+    result = query(
+        "{ fruits(filters: { name: { exact: null, contains: null } }) { id name } }"
+    )
+    assert not result.errors
+    assert result.data["fruits"] == [
+        {"id": "1", "name": "strawberry"},
+        {"id": "2", "name": "raspberry"},
+        {"id": "3", "name": "banana"},
+    ]
+
+
 def test_exact(query, fruits):
     result = query('{ fruits(filters: { name: { exact: "strawberry" } }) { id name } }')
     assert not result.errors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->


When a lookup is detected, ignore null values.
This PR is a bit conservative and also ignores UNSET but this is most probably not necessary.

This prevents django errors for null specifications and ignores null like the rest of the API does.

Is an exception for the filter exact wanted (e.g. foo_exact=null)? Shall I make a settings switch?

note: exact=null is the same like is_null=true, so there would be no functionality loss, when exact=null would not filter anymore


<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->


<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*  #459

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
