### PR TITLE
Deduce model field names from custom prefetches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "strawberry-graphql-django"
 packages = [{ include = "strawberry_django" }]
-version = "0.28.5"
+version = "0.30.1"
 description = "Strawberry GraphQL Django extension"
 authors = [
   "Lauri Hintsala <lauri.hintsala@verkkopaja.fi>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ exclude = [
 "**/migrations/*" = ["RUF012"]
 
 [tool.ruff.lint.pylint]
-max-nested-blocks = 7
+max-nested-blocks = 8
 
 [tool.ruff.lint.isort]
 

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -496,7 +496,7 @@ def _get_model_hints(
         if model_attr is not None and isinstance(model_attr, ModelProperty):
             attr_store = model_attr.store
             store |= attr_store.with_prefix(prefix, info=info) if prefix else attr_store
-            attr_store_prefetches = attr_store.get_custom_prefetches()
+            attr_store_prefetches = attr_store.get_custom_prefetches(info)
             if attr_store_prefetches:
                 custom_prefetches.extend(attr_store_prefetches)
 

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -12,10 +12,10 @@ from typing import (
     Callable,
     ForwardRef,
     Generator,
+    Optional,
     Type,
     TypeVar,
     cast,
-    Optional,
 )
 
 from django.db import models
@@ -523,10 +523,14 @@ def _get_model_hints(
         # Lastly, from the django field itself
         if not model_fieldname:
             model_fieldname = getattr(field, "django_name", None) or field.python_name
-            model_field = model_fields.get(model_fieldname, None) if model_fieldname else None
+            model_field = (
+                model_fields.get(model_fieldname, None) if model_fieldname else None
+            )
 
         if model_field is not None:
-            assert model_fieldname is not None  # if we have a model_field, then model_fieldname must also be set
+            assert (
+                model_fieldname is not None
+            )  # if we have a model_field, then model_fieldname must also be set
             path = f"{prefix}{model_fieldname}"
 
             if not custom_prefetches and isinstance(
@@ -649,7 +653,9 @@ def _get_model_hints(
                                 f_qs = f_store.apply(p_qs, info=info, config=config)
                                 f_prefetch = Prefetch(
                                     # to_attr is not typed in django stubs
-                                    prefetch.prefetch_through, f_qs, prefetch.to_attr  # type: ignore
+                                    prefetch.prefetch_through,
+                                    f_qs,
+                                    prefetch.to_attr,  # type: ignore
                                 )
                                 if prefix:
                                     f_prefetch.add_prefix(prefix)

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -526,7 +526,9 @@ def _get_model_hints(
         if model_field is not None:
             path = f"{prefix}{model_fieldname}"
 
-            if not custom_prefetches and isinstance(model_field, (models.ForeignKey, OneToOneRel)):
+            if not custom_prefetches and isinstance(
+                model_field, (models.ForeignKey, OneToOneRel)
+            ):
                 # only select_related if there is no custom prefetch
                 store.only.append(path)
                 store.select_related.append(path)
@@ -554,7 +556,11 @@ def _get_model_hints(
                     if f_store is not None:
                         cache.setdefault(f_model, []).append((level, f_store))
                         store |= f_store.with_prefix(path, info=info)
-            elif not custom_prefetches and GenericForeignKey and isinstance(model_field, GenericForeignKey):
+            elif (
+                not custom_prefetches
+                and GenericForeignKey
+                and isinstance(model_field, GenericForeignKey)
+            ):
                 # There's not much we can do to optimize generic foreign keys regarding
                 # only/select_related because they can be anything.
                 # Just prefetch_related them
@@ -633,9 +639,13 @@ def _get_model_hints(
                                 if prefetch.queryset is not None:
                                     p_qs = prefetch.queryset
                                 else:
-                                    p_qs = _get_prefetch_queryset(remote_model, field, config, info)
+                                    p_qs = _get_prefetch_queryset(
+                                        remote_model, field, config, info
+                                    )
                                 f_qs = f_store.apply(p_qs, info=info, config=config)
-                                f_prefetch = Prefetch(prefetch.prefetch_through, f_qs, prefetch.to_attr)
+                                f_prefetch = Prefetch(
+                                    prefetch.prefetch_through, f_qs, prefetch.to_attr
+                                )
                                 if prefix:
                                     f_prefetch.add_prefix(prefix)
                                 f_prefetch._optimizer_sentinel = _sentinel  # type: ignore

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -196,7 +196,7 @@ class OptimizerStore:
                 assert_type(p, PrefetchCallable)
                 p = p(info)  # noqa: PLW2901
 
-            if isinstance(p, Prefetch) and p.queryset is not None and p.to_attr is not None:
+            if isinstance(p, Prefetch) and p.to_attr is not None:
                 custom_prefetches.append(p)
         return custom_prefetches
 
@@ -630,9 +630,11 @@ def _get_model_hints(
 
                         if custom_prefetches:
                             for prefetch in custom_prefetches:
-                                f_qs = f_store.apply(
-                                    prefetch.queryset, info=info, config=config
-                                )
+                                if prefetch.queryset is not None:
+                                    p_qs = prefetch.queryset
+                                else:
+                                    p_qs = _get_prefetch_queryset(remote_model, field, config, info)
+                                f_qs = f_store.apply(p_qs, info=info, config=config)
                                 f_prefetch = Prefetch(prefetch.prefetch_through, f_qs, prefetch.to_attr)
                                 if prefix:
                                     f_prefetch.add_prefix(prefix)

--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -72,7 +72,7 @@ class Project(models.Model):
     def next_milestones_property(
         self,
     ) -> List[Annotated["MilestoneType", strawberry.lazy(".schema")]]:
-        """The milestones for the project ordered by their due date"""
+        """Return the milestones for the project ordered by their due date."""
         if hasattr(self, "next_milestones_prop_pf"):
             return cast(List["MilestoneType"], self.next_milestones_prop_pf)
         return cast(

--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -1,9 +1,9 @@
-from typing import TYPE_CHECKING, Any, Optional, Annotated
+from typing import TYPE_CHECKING, Annotated, Any, Optional
 
 import strawberry
 from django.contrib.auth import get_user_model
 from django.db import models
-from django.db.models import Count, QuerySet, Prefetch
+from django.db.models import Count, Prefetch, QuerySet
 from django.utils.translation import gettext_lazy as _
 from django_choices_field import TextChoicesField
 
@@ -59,17 +59,19 @@ class Project(models.Model):
         prefetch_related=lambda _: Prefetch(
             "milestones",
             to_attr="next_milestones_prop_pf",
-            queryset=Milestone.objects.filter(due_date__isnull=False).order_by("due_date")
+            queryset=Milestone.objects.filter(due_date__isnull=False).order_by(
+                "due_date"
+            ),
         )
     )
-    def next_milestones_property(self) -> list[Annotated['MilestoneType', strawberry.lazy('.schema')]]:
+    def next_milestones_property(
+        self,
+    ) -> list[Annotated["MilestoneType", strawberry.lazy(".schema")]]:
+        """The milestones for the project ordered by their due date
         """
-        The milestones for the project ordered by their due date
-        """
-        if hasattr(self, 'next_milestones_prop_pf'):
+        if hasattr(self, "next_milestones_prop_pf"):
             return self.next_milestones_prop_pf
-        else:
-            return self.milestones.filter(due_date__isnull=False).order_by("due_date")
+        return self.milestones.filter(due_date__isnull=False).order_by("due_date")
 
 
 class Milestone(models.Model):

--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 import strawberry
 from django.contrib.auth import get_user_model
@@ -74,8 +74,8 @@ class Project(models.Model):
     ) -> List[Annotated["MilestoneType", strawberry.lazy(".schema")]]:
         """The milestones for the project ordered by their due date"""
         if hasattr(self, "next_milestones_prop_pf"):
-            return self.next_milestones_prop_pf  # type: ignore
-        return self.milestones.filter(due_date__isnull=False).order_by("due_date")  # type: ignore
+            return cast(List["MilestoneType"], self.next_milestones_prop_pf)
+        return cast(List["MilestoneType"], self.milestones.filter(due_date__isnull=False).order_by("due_date"))
 
 
 class Milestone(models.Model):
@@ -100,6 +100,8 @@ class Milestone(models.Model):
         related_name="milestones",
         related_query_name="milestone",
     )
+
+    next_milestones_pf: List["Milestone"]
 
 
 class FavoriteQuerySet(QuerySet):

--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -1,8 +1,9 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Annotated
 
+import strawberry
 from django.contrib.auth import get_user_model
 from django.db import models
-from django.db.models import Count, QuerySet
+from django.db.models import Count, QuerySet, Prefetch
 from django.utils.translation import gettext_lazy as _
 from django_choices_field import TextChoicesField
 
@@ -53,6 +54,22 @@ class Project(models.Model):
     @model_property(annotate={"_milestone_count": Count("milestone")})
     def is_small(self) -> bool:
         return self._milestone_count < 3  # type: ignore
+
+    @model_property(
+        prefetch_related=lambda _: Prefetch(
+            "milestones",
+            to_attr="next_milestones_prop_pf",
+            queryset=Milestone.objects.filter(due_date__isnull=False).order_by("due_date")
+        )
+    )
+    def next_milestones_property(self) -> list[Annotated['MilestoneType', strawberry.lazy('.schema')]]:
+        """
+        The milestones for the project ordered by their due date
+        """
+        if hasattr(self, 'next_milestones_prop_pf'):
+            return self.next_milestones_prop_pf
+        else:
+            return self.milestones.filter(due_date__isnull=False).order_by("due_date")
 
 
 class Milestone(models.Model):

--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Annotated, Any, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
+from typing_extensions import Annotated
 
 import strawberry
 from django.contrib.auth import get_user_model
@@ -12,6 +13,7 @@ from strawberry_django.utils.typing import UserType
 
 if TYPE_CHECKING:
     from django.db.models.manager import RelatedManager
+    from .schema import MilestoneType
 
 User = get_user_model()
 
@@ -51,6 +53,8 @@ class Project(models.Model):
         default=None,
     )
 
+    next_milestones_prop_pf: List["Milestone"]
+
     @model_property(annotate={"_milestone_count": Count("milestone")})
     def is_small(self) -> bool:
         return self._milestone_count < 3  # type: ignore
@@ -66,12 +70,12 @@ class Project(models.Model):
     )
     def next_milestones_property(
         self,
-    ) -> list[Annotated["MilestoneType", strawberry.lazy(".schema")]]:
+    ) -> List[Annotated["MilestoneType", strawberry.lazy(".schema")]]:
         """The milestones for the project ordered by their due date
         """
         if hasattr(self, "next_milestones_prop_pf"):
-            return self.next_milestones_prop_pf
-        return self.milestones.filter(due_date__isnull=False).order_by("due_date")
+            return self.next_milestones_prop_pf  # type: ignore
+        return self.milestones.filter(due_date__isnull=False).order_by("due_date")  # type: ignore
 
 
 class Milestone(models.Model):

--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, Any, List, Optional
-from typing_extensions import Annotated
 
 import strawberry
 from django.contrib.auth import get_user_model
@@ -7,12 +6,14 @@ from django.db import models
 from django.db.models import Count, Prefetch, QuerySet
 from django.utils.translation import gettext_lazy as _
 from django_choices_field import TextChoicesField
+from typing_extensions import Annotated
 
 from strawberry_django.descriptors import model_property
 from strawberry_django.utils.typing import UserType
 
 if TYPE_CHECKING:
     from django.db.models.manager import RelatedManager
+
     from .schema import MilestoneType
 
 User = get_user_model()
@@ -71,8 +72,7 @@ class Project(models.Model):
     def next_milestones_property(
         self,
     ) -> List[Annotated["MilestoneType", strawberry.lazy(".schema")]]:
-        """The milestones for the project ordered by their due date
-        """
+        """The milestones for the project ordered by their due date"""
         if hasattr(self, "next_milestones_prop_pf"):
             return self.next_milestones_prop_pf  # type: ignore
         return self.milestones.filter(due_date__isnull=False).order_by("due_date")  # type: ignore

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -103,6 +103,8 @@ class ProjectType(relay.Node):
     cost: strawberry.auto = strawberry_django.field(extensions=[IsAuthenticated()])
     is_small: strawberry.auto
 
+    next_milestones_property: strawberry.auto
+
     @strawberry_django.field(
         prefetch_related=lambda _: Prefetch(
             "milestones",

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -115,7 +115,7 @@ class ProjectType(relay.Node):
         )
     )
     def next_milestones(self, root: Milestone) -> "List[MilestoneType]":
-        """The milestones for the project ordered by their due date"""
+        """Return the milestones for the project ordered by their due date."""
         if hasattr(root, "next_milestones_pf"):
             return cast(List[MilestoneType], root.next_milestones_pf)
         return root.milestones.filter(due_date__isnull=False).order_by("due_date")  # type: ignore

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -1,7 +1,7 @@
 import asyncio
 import datetime
 import decimal
-from typing import Iterable, List, Optional, Type, cast, Union
+from typing import Iterable, List, Optional, Type, Union, cast
 
 import strawberry
 from django.contrib.auth import get_user_model
@@ -109,17 +109,17 @@ class ProjectType(relay.Node):
         prefetch_related=lambda _: Prefetch(
             "milestones",
             to_attr="next_milestones_pf",
-            queryset=Milestone.objects.filter(due_date__isnull=False).order_by("due_date")
+            queryset=Milestone.objects.filter(due_date__isnull=False).order_by(
+                "due_date"
+            ),
         )
     )
     def next_milestones(self) -> "list[MilestoneType]":
+        """The milestones for the project ordered by their due date
         """
-        The milestones for the project ordered by their due date
-        """
-        if hasattr(self, 'next_milestones_pf'):
+        if hasattr(self, "next_milestones_pf"):
             return self.next_milestones_pf
-        else:
-            return self.milestones.filter(due_date__isnull=False).order_by("due_date")
+        return self.milestones.filter(due_date__isnull=False).order_by("due_date")
 
 
 @strawberry_django.filter(Milestone, lookups=True)
@@ -314,7 +314,9 @@ class ProjectConnection(ListConnectionWithTotalCount[ProjectType]):
     """Project connection documentation."""
 
 
-ProjectFeedItem = Annotated[Union[IssueType, MilestoneType], strawberry.union('ProjectFeedItem')]
+ProjectFeedItem = Annotated[
+    Union[IssueType, MilestoneType], strawberry.union("ProjectFeedItem")
+]
 
 
 @strawberry.type

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -104,6 +104,7 @@ class ProjectType(relay.Node):
     is_small: strawberry.auto
 
     next_milestones_property: strawberry.auto
+    next_milestones_pf: List[Milestone]
 
     @strawberry_django.field(
         prefetch_related=lambda _: Prefetch(
@@ -114,12 +115,12 @@ class ProjectType(relay.Node):
             ),
         )
     )
-    def next_milestones(self) -> "list[MilestoneType]":
+    def next_milestones(self) -> "List[MilestoneType]":
         """The milestones for the project ordered by their due date
         """
         if hasattr(self, "next_milestones_pf"):
-            return self.next_milestones_pf
-        return self.milestones.filter(due_date__isnull=False).order_by("due_date")
+            return self.next_milestones_pf  # type: ignore
+        return self.milestones.filter(due_date__isnull=False).order_by("due_date")  # type: ignore
 
 
 @strawberry_django.filter(Milestone, lookups=True)

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -114,11 +114,11 @@ class ProjectType(relay.Node):
             ),
         )
     )
-    def next_milestones(self) -> "List[MilestoneType]":
+    def next_milestones(self, root: Milestone) -> "List[MilestoneType]":
         """The milestones for the project ordered by their due date"""
-        if hasattr(self, "next_milestones_pf"):
-            return self.next_milestones_pf  # type: ignore
-        return self.milestones.filter(due_date__isnull=False).order_by("due_date")  # type: ignore
+        if hasattr(root, "next_milestones_pf"):
+            return cast(List[MilestoneType], root.next_milestones_pf)
+        return root.milestones.filter(due_date__isnull=False).order_by("due_date")  # type: ignore
 
 
 @strawberry_django.filter(Milestone, lookups=True)

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -104,7 +104,6 @@ class ProjectType(relay.Node):
     is_small: strawberry.auto
 
     next_milestones_property: strawberry.auto
-    next_milestones_pf: List[Milestone]
 
     @strawberry_django.field(
         prefetch_related=lambda _: Prefetch(

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -116,8 +116,7 @@ class ProjectType(relay.Node):
         )
     )
     def next_milestones(self) -> "List[MilestoneType]":
-        """The milestones for the project ordered by their due date
-        """
+        """The milestones for the project ordered by their due date"""
         if hasattr(self, "next_milestones_pf"):
             return self.next_milestones_pf  # type: ignore
         return self.milestones.filter(due_date__isnull=False).order_by("due_date")  # type: ignore

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -471,6 +471,8 @@ type ProjectType implements Node {
   isDelayed: Boolean!
   cost: Decimal @isAuthenticated
   isSmall: Boolean!
+  nextMilestonesProperty(filters: MilestoneFilter, order: MilestoneOrder): [MilestoneType!]!
+  nextMilestones: [MilestoneType!]!
 }
 
 """An edge in a connection."""

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -580,6 +580,51 @@ def test_query_prefetch_with_to_attr(db, gql_client: GraphQLTestClient):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_query_prefetch_with_to_attr_model_property(db, gql_client: GraphQLTestClient):
+    query = """
+      query TestQuery {
+        projectList {
+          id
+          nextMilestonesProperty {
+            id
+            name
+            project {
+              id
+              name
+            }
+          }
+        }
+      }
+    """
+
+    expected = []
+    for p in ProjectFactory.create_batch(2):
+        p_res: dict[str, Any] = {
+            "id": to_base64("ProjectType", p.id),
+            "nextMilestonesProperty": [],
+        }
+        expected.append(p_res)
+        milestones = MilestoneFactory.create_batch(2, project=p)
+        milestones.sort(key=lambda ms: ms.due_date)
+        for m in milestones:
+            m_res: dict[str, Any] = {
+                "id": to_base64("MilestoneType", m.id),
+                "name": m.name,
+                "project": {
+                    "id": p_res["id"],
+                    "name": p.name,
+                },
+            }
+            p_res["nextMilestonesProperty"].append(m_res)
+
+    assert len(expected) == 2
+
+    with assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 3):
+        res = gql_client.query(query)
+    assert res.data == {"projectList": expected}
+
+
+@pytest.mark.django_db(transaction=True)
 def test_query_connection_with_resolver(db, gql_client: GraphQLTestClient):
     query = """
       query TestQuery {

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -560,7 +560,7 @@ def test_query_prefetch_with_to_attr(db, gql_client: GraphQLTestClient):
         }
         expected.append(p_res)
         milestones = MilestoneFactory.create_batch(2, project=p)
-        milestones.sort(key=lambda ms: ms.due_date)
+        milestones.sort(key=lambda ms: cast(datetime.datetime, ms.due_date))
         for m in milestones:
             m_res: dict[str, Any] = {
                 "id": to_base64("MilestoneType", m.id),
@@ -605,7 +605,7 @@ def test_query_prefetch_with_to_attr_model_property(db, gql_client: GraphQLTestC
         }
         expected.append(p_res)
         milestones = MilestoneFactory.create_batch(2, project=p)
-        milestones.sort(key=lambda ms: ms.due_date)
+        milestones.sort(key=lambda ms: cast(datetime.datetime, ms.due_date))
         for m in milestones:
             m_res: dict[str, Any] = {
                 "id": to_base64("MilestoneType", m.id),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently the QuerySet optimizer is oblivious to custom `prefetch_related` like the following:
```python
@strawberry_django.type(models.Project)
class ProjectType(models.Project):
      @strawberry_django.field(
        prefetch_related=lambda _: Prefetch(
            "milestones",
            to_attr="next_milestones_pf",
            queryset=Milestone.objects.filter(due_date__isnull=False).order_by("due_date")
        )
    )
    def next_milestones(self) -> "list[MilestoneType]":
        return self.next_milestones_pf
```

The current optimizer cannot understand how to optimize "through" this prefetch, because it cannot find the model field (`milestones` in `Project`) that the field uses.
This results in the optimization essentially stopping at the `next_milestones` field and any further nested relations will cause N+1 issues.

This pull request attempts to address this shortcoming.

<!--- Describe your changes in detail here. -->

## Types of Changes

Now the optimizer first inspects the field configuration to find any custom `Prefetch`. A custom prefetch is one which has a custom `to_attr`  set. The optimizer then uses these custom Prefetches to perform further optimization instead of stopping here.

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry-graphql-django/issues/389

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
