### PR TITLE
fix: cache definitions in optimizer

### DIFF
--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -695,7 +695,9 @@ def optimize(
                 interface_definitions = []
                 for t in schema.schema_converter.type_map.values():
                     t_definition = t.definition
-                    if isinstance(t_definition, StrawberryObjectDefinition) and issubclass(t_definition.origin, object_definition.origin):
+                    if isinstance(
+                        t_definition, StrawberryObjectDefinition
+                    ) and issubclass(t_definition.origin, object_definition.origin):
                         interface_definitions.append(t_definition)
                 _interfaces[schema][object_definition] = interface_definitions
 

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -690,21 +690,20 @@ def optimize(
 
     for object_definition in get_possible_type_definitions(strawberry_type):
         if object_definition.is_interface:
-            object_definitions = _interfaces[schema].get(object_definition)
-            if object_definitions is None:
-                object_definitions = []
-
+            interface_definitions = _interfaces[schema].get(object_definition)
+            if interface_definitions is None:
+                interface_definitions = []
                 for t in schema.schema_converter.type_map.values():
                     t_definition = t.definition
-                    if not isinstance(t_definition, StrawberryObjectDefinition):
-                        continue
+                    if isinstance(t_definition, StrawberryObjectDefinition) and issubclass(t_definition.origin, object_definition.origin):
+                        interface_definitions.append(t_definition)
+                _interfaces[schema][object_definition] = interface_definitions
 
-                    if issubclass(t_definition.origin, object_definition.origin):
-                        dj_definition = get_django_definition(t_definition.origin)
-                        if dj_definition and issubclass(qs.model, dj_definition.model):
-                            object_definitions.append(t_definition)
-
-                _interfaces[schema][object_definition] = object_definitions
+            object_definitions = []
+            for interface_definition in interface_definitions:
+                dj_definition = get_django_definition(interface_definition.origin)
+                if dj_definition and issubclass(qs.model, dj_definition.model):
+                    object_definitions.append(interface_definition)
         else:
             object_definitions = [object_definition]
 


### PR DESCRIPTION
Only 1 subtype of an interface types (e.g Node) is optimized. This PR fixes the optimizer's ```_interfaces`` cache, so that all interfaces are considered for optimization. I assume that the cache was introduced to avoid a performance hit (having to iterate over all the schema's types) every time an interface has to be optimized.

Before this PR, the following would happen. Suppose that we have A and B, both implementing the Node interface:
- We resolve node for an instance of A: The ``_interfaces`` cache is empty. The optimizer will add to the ``_interfaces`` cache only A, which will get all the optimization hints
- We resolve a node for an instance of B: The ``_interfaces`` cache contains only A. The optimizer will fail to optimize B.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
