### PR TITLE
Fix permissioned pagination

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -279,10 +279,7 @@ class StrawberryDjangoField(
         if get_queryset:
             queryset = get_queryset(queryset, info, **kwargs)
 
-        queryset = filter_with_perms(
-            super().get_queryset(queryset, info, **kwargs),
-            info,
-        )
+        queryset = super().get_queryset(filter_with_perms(queryset, info),info, **kwargs)
 
         # If optimizer extension is enabled, optimize this queryset
         ext = optimizer.optimizer.get()

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -279,7 +279,9 @@ class StrawberryDjangoField(
         if get_queryset:
             queryset = get_queryset(queryset, info, **kwargs)
 
-        queryset = super().get_queryset(filter_with_perms(queryset, info),info, **kwargs)
+        queryset = super().get_queryset(
+            filter_with_perms(queryset, info), info, **kwargs
+        )
 
         # If optimizer extension is enabled, optimize this queryset
         ext = optimizer.optimizer.get()

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -387,6 +387,9 @@ class Query:
     issue_list_obj_perm_required: List[IssueType] = strawberry_django.field(
         extensions=[HasRetvalPerm(perms=["projects.view_issue"])],
     )
+    issue_list_obj_perm_required_paginated: List[IssueType] = strawberry_django.field(
+        extensions=[HasRetvalPerm(perms=["projects.view_issue"])], pagination=True
+    )
     issue_conn_obj_perm_required: ListConnectionWithTotalCount[IssueType] = (
         strawberry_django.connection(
             extensions=[HasRetvalPerm(perms=["projects.view_issue"])],

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -671,6 +671,7 @@ type Query {
     id: GlobalID!
   ): IssueType @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListObjPermRequired: [IssueType!]! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
+  issueListObjPermRequiredPaginated(pagination: OffsetPaginationInput): [IssueType!]! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueConnObjPermRequired(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -768,9 +768,12 @@ def test_list_obj_perm_required(db, gql_client: GraphQLTestClient, kind: PermKin
                 ],
             }
 
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize("kind", perm_kinds)
-def test_list_obj_perm_required_paginated(db, gql_client: GraphQLTestClient, kind: PermKind):
+def test_list_obj_perm_required_paginated(
+    db, gql_client: GraphQLTestClient, kind: PermKind
+):
     query = """
     query Issue {
         issueListObjPermRequiredPaginated(pagination: {limit: 10, offset: 0}) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Fixes an error when trying to apply permission checks using the `HasRetvalPerm` extension on a paginated list. 

> TypeError: Cannot filter a query once a slice has been taken.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fix https://github.com/strawberry-graphql/strawberry-django/issues/471

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
