### PR TITLE
feat: allow extensions to prevent results from being fetched

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -114,6 +114,9 @@ class StrawberryDjangoField(
             prefetch_related=prefetch_related,
             annotate=annotate,
         )
+        # FIXME: Probably remove this when depending on graphql-core 3.3.0+
+        self.disable_fetch_list_results: bool = False
+
         super().__init__(*args, **kwargs)
 
     def __copy__(self) -> Self:
@@ -256,7 +259,9 @@ class StrawberryDjangoField(
 
             def qs_hook(qs: models.QuerySet):  # type: ignore
                 qs = self.get_queryset(qs, info, **kwargs)
-                return default_qs_hook(qs)
+                if not self.disable_fetch_list_results:
+                    qs = default_qs_hook(qs)
+                return qs
 
         elif self.is_optional:
 

--- a/strawberry_django/resolvers.py
+++ b/strawberry_django/resolvers.py
@@ -27,6 +27,9 @@ resolving_async: contextvars.ContextVar[bool] = contextvars.ContextVar(
 
 
 def default_qs_hook(qs: models.QuerySet[_M]) -> models.QuerySet[_M]:
+    # FIXME: We probably won't need this anymore when we can use graphql-core 3.3.0+
+    # as its `complete_list_value` gives a preference to async iteration it if is
+    # provided by the object.
     # This is what QuerySet does internally to fetch results.
     # After this, iterating over the queryset should be async safe
     if qs._result_cache is None:  # type: ignore

--- a/tests/fields/test_get_result.py
+++ b/tests/fields/test_get_result.py
@@ -1,0 +1,70 @@
+from typing import List
+
+import pytest
+from django.db.models import QuerySet
+from strawberry import relay
+from strawberry.annotation import StrawberryAnnotation
+from strawberry.relay.types import ListConnection
+
+from strawberry_django.fields.field import StrawberryDjangoField
+from tests.types import FruitType
+
+
+@pytest.mark.django_db()
+def test_resolve_returns_queryset_with_fetched_results():
+    field = StrawberryDjangoField(type_annotation=StrawberryAnnotation(List[FruitType]))
+    result = field.get_result(None, None, [], {})
+    assert isinstance(result, QuerySet)
+    assert result._result_cache is not None  # type: ignore
+
+
+@pytest.mark.django_db()
+async def test_resolve_returns_queryset_with_fetched_results_async():
+    field = StrawberryDjangoField(type_annotation=StrawberryAnnotation(List[FruitType]))
+    result = await field.get_result(None, None, [], {})
+    assert isinstance(result, QuerySet)
+    assert result._result_cache is not None  # type: ignore
+
+
+@pytest.mark.django_db()
+def test_resolve_returns_queryset_without_fetching_results_when_disabling_it():
+    field = StrawberryDjangoField(type_annotation=StrawberryAnnotation(List[FruitType]))
+    field.disable_fetch_list_results = True
+    result = field.get_result(None, None, [], {})
+    assert isinstance(result, QuerySet)
+    assert result._result_cache is None  # type: ignore
+
+
+@pytest.mark.django_db()
+async def test_resolve_returns_queryset_without_fetching_results_when_disabling_it_async():
+    field = StrawberryDjangoField(type_annotation=StrawberryAnnotation(List[FruitType]))
+    field.disable_fetch_list_results = True
+    result = await field.get_result(None, None, [], {})
+    assert isinstance(result, QuerySet)
+    assert result._result_cache is None  # type: ignore
+
+
+@pytest.mark.django_db()
+def test_resolve_returns_queryset_without_fetching_results_for_connections():
+    class FruitImplementingNode(relay.Node, FruitType): ...
+
+    field = StrawberryDjangoField(
+        type_annotation=StrawberryAnnotation(ListConnection[FruitImplementingNode])
+    )
+    field.disable_fetch_list_results = True
+    result = field.get_result(None, None, [], {})
+    assert isinstance(result, QuerySet)
+    assert result._result_cache is None  # type: ignore
+
+
+@pytest.mark.django_db()
+async def test_resolve_returns_queryset_without_fetching_results_for_connections_async():
+    class FruitImplementingNode(relay.Node, FruitType): ...
+
+    field = StrawberryDjangoField(
+        type_annotation=StrawberryAnnotation(ListConnection[FruitImplementingNode])
+    )
+    field.disable_fetch_list_results = True
+    result = await field.get_result(None, None, [], {})
+    assert isinstance(result, QuerySet)
+    assert result._result_cache is None  # type: ignore


### PR DESCRIPTION
Currently we have to `qs._fetch_all()` because graphql-core will try to iterate
over the `QuerySet` in a sync way, thus causing issues when running ASGI.

This adds a way for extensions to prevent that from happening, as discussed in https://github.com/strawberry-graphql/strawberry/issues/3364

When `grapghql-core` 3.3.0 is released we can probably stop fetching results at all,
as it will give preference to use `__aiter__` if the object provides one (and the `QuerySet` does)
