### PR TITLE
feat: Avoid joins when only fetching an ID

### DIFF
--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -492,7 +492,6 @@ def _get_model_hints(
 
             if isinstance(model_field, (models.ForeignKey, OneToOneRel)):
                 store.only.append(path)
-                store.select_related.append(path)
 
                 # If adding a reverse relation, make sure to select its pointer to us,
                 # or else this might causa a refetch from the database
@@ -514,7 +513,8 @@ def _get_model_hints(
                         cache=cache,
                         level=level + 1,
                     )
-                    if f_store is not None:
+                    if f_store is not None and set(f_store.only) != {model_field.target_field.attname}:
+                        store.select_related.append(path)
                         cache.setdefault(f_model, []).append((level, f_store))
                         store |= f_store.with_prefix(path, info=info)
             elif GenericForeignKey and isinstance(model_field, GenericForeignKey):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Consider the following query
```gql
query Query {
  books {
    id
    author {
      id
    }
  }
}
```
A join will be generated even though we really don't have to, as the required information already exists through `book.author_id`.
The idea here is to try and optimize away this join, by constructing the `Author` object in-memory using the value from `book.author_id`.

I'm not very familiar with the code base, so I'm not sure if this is has other drawbacks.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
