### PR TITLE
fix: OneToManyInput saves and runs validation on foreign key #487

### DIFF
--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -251,10 +251,17 @@ def prepare_create_update(
             )
             if value is None and not value_data:
                 value = None  # noqa: PLW2901
+
+            # If foreign object is not found, then create it
             elif value is None:
                 value = field.related_model._default_manager.create(  # noqa: PLW2901
                     **value_data,
                 )
+
+            # If foreign object does not need updating, then skip it
+            elif isinstance(value_data, dict) and not value_data:
+                pass
+
             else:
                 update(
                     info, value, value_data, full_clean=full_clean, key_attr=key_attr
@@ -441,10 +448,10 @@ def update(
 
     instance.save()
 
-    for field, value in m2m:
-        update_m2m(info, instance, field, value, key_attr, full_clean)
-
-    instance.refresh_from_db()
+    if m2m:
+        for field, value in m2m:
+            update_m2m(info, instance, field, value, key_attr, full_clean)
+        instance.refresh_from_db()
 
     return instance
 

--- a/tests/mutations/test_relationship.py
+++ b/tests/mutations/test_relationship.py
@@ -1,3 +1,9 @@
+"""Test the functionality of CUD relationships.
+
+Foreign key relationships in a GraphQL API context.
+It includes tests for one-to-many, many-to-one, and many-to-many relationships.
+"""
+
 import pytest
 
 from tests import models
@@ -34,6 +40,18 @@ def test_update_one_to_many(mutation, fruit, color):
     )
     assert not result.errors
     assert result.data["fruits"] == [{"color": None}]
+
+
+def test_patch_one_to_many(mutation, fruit, color, django_assert_max_num_queries):
+    # Issue 487: At maximum, 11 queries are expected to be executed:
+    # 6x SAVEPOINT, 4x SELECT, 1x UPDATE
+    with django_assert_max_num_queries(12):
+        result = mutation(
+            '{ fruits: updateFruits(filters: { id: { exact: "1"} }, '
+            "data: { color: { set: 1 } }) { color { name } } }",
+        )
+    assert not result.errors
+    assert result.data["fruits"] == [{"color": {"name": color.name}}]
 
 
 def test_update_many_to_one(mutation, fruit, color):


### PR DESCRIPTION
## Description

Fix for [issue described in #487](**[url](https://github.com/strawberry-graphql/strawberry-django/issues/487)**)

Notes:
- Used django_assert_max_num_queries to write test
- Reduced the number of queries for a "patch" update from 25 to 12
- `test_relation.py` was blank so deleted it.
- As a new contributor, I found it confusing which tests go where so added docstring to `test_relationship` to clarify my understanding

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry-django/issues/487

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
