### PR TITLE
fix: use str() to trigger eventual django's gettext_lazy string

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -15,7 +15,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
 )
 
 import django
@@ -445,7 +444,6 @@ def resolve_model_field_type(
             int,
         )  # Exclude IntegerChoices
     ):
-        choices = cast(List[Tuple[Any, str]], model_field.choices)
         field_type = getattr(model_field, "_strawberry_enum", None)
         if field_type is None:
             meta = model_field.model._meta
@@ -460,8 +458,9 @@ def resolve_model_field_type(
                         ),
                     ),
                     {
-                        c[0]: EnumValueDefinition(value=c[0], description=c[1])
-                        for c in choices
+                        # use str() to trigger eventual django's gettext_lazy string
+                        c[0]: EnumValueDefinition(value=c[0], description=str(c[1]))
+                        for c in model_field.choices
                     },
                 ),
                 description=(

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -4,6 +4,7 @@ from typing import cast
 import strawberry
 from django.db import models
 from django.test import override_settings
+from django.utils.translation import gettext_lazy
 from django_choices_field import IntegerChoicesField, TextChoicesField
 from pytest_mock import MockerFixture
 
@@ -18,7 +19,7 @@ class Choice(models.TextChoices):
 
     A = "a", "A description"
     B = "b", "B description"
-    C = "c", "C description"
+    C = "c", gettext_lazy("C description")
 
 
 class IntegerChoice(models.IntegerChoices):
@@ -26,7 +27,7 @@ class IntegerChoice(models.IntegerChoices):
 
     X = 1, "1 description"
     Y = 2, "2 description"
-    Z = 3, "3 description"
+    Z = 3, gettext_lazy("3 description")
 
 
 class ChoicesModel(models.Model):
@@ -36,13 +37,13 @@ class ChoicesModel(models.Model):
         max_length=255,
         choices=[
             ("c", "C description"),
-            ("d", "D description"),
+            ("d", gettext_lazy("D description")),
         ],
     )
     attr4 = models.IntegerField(
         choices=[
             (4, "4 description"),
-            (5, "5 description"),
+            (5, gettext_lazy("5 description")),
         ],
     )
     attr5 = models.CharField(
@@ -61,13 +62,13 @@ class ChoicesWithExtraFieldsModel(models.Model):
         max_length=255,
         choices=[
             ("c", "C description"),
-            ("d", "D description"),
+            ("d", gettext_lazy("D description")),
         ],
     )
     attr4 = models.IntegerField(
         choices=[
             (4, "4 description"),
-            (5, "5 description"),
+            (5, gettext_lazy("5 description")),
         ],
     )
     attr5 = models.CharField(


### PR DESCRIPTION
The generate enum from choices feature fail when choice description is a django's lazy string (gettext_lazy used with translation framework) 

## Description

Use `str()` on description to trigger string translation when generating Enum.


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fix #489 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
