### PR TITLE
Fix/489 auto enum value allowed chars

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -455,6 +455,9 @@ def resolve_model_field_type(
                 choice_name = re.sub(r"^[^_a-zA-Z]|[^_a-zA-Z0-9]", "_", c[0])
                 # use str() to trigger eventual django's gettext_lazy string
                 choice_value = EnumValueDefinition(value=c[0], description=str(c[1]))
+
+                while choice_name in enum_choices:
+                    choice_name = choice_name + "_"
                 enum_choices[choice_name] = choice_value
 
             field_type = strawberry.enum(  # type: ignore

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -452,7 +452,7 @@ def resolve_model_field_type(
             enum_choices = {}
             for c in model_field.choices:
                 # replace chars not compatible with GraphQL naming convention
-                choice_name = re.sub(r"^[^a-zA-Z]|[^a-zA-Z0-9]", "_", c[0])
+                choice_name = re.sub(r"^[^_a-zA-Z]|[^_a-zA-Z0-9]", "_", c[0])
                 # use str() to trigger eventual django's gettext_lazy string
                 choice_value = EnumValueDefinition(value=c[0], description=str(c[1]))
                 enum_choices[choice_name] = choice_value

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -15,7 +15,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
 )
 
 import django
@@ -445,7 +444,6 @@ def resolve_model_field_type(
             int,
         )  # Exclude IntegerChoices
     ):
-        choices = cast(List[Tuple[Any, str]], model_field.choices)
         field_type = getattr(model_field, "_strawberry_enum", None)
         if field_type is None:
             meta = model_field.model._meta
@@ -460,8 +458,9 @@ def resolve_model_field_type(
                         ),
                     ),
                     {
-                        c[0]: EnumValueDefinition(value=c[0], description=c[1])
-                        for c in choices
+                        # use str() to trigger eventual django's gettext_lazy string
+                        c[0]: EnumValueDefinition(value=c[0], description=str(c[1]))
+                        for c in model_field.choices
                     },
                 ),
                 description=(

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -20,6 +20,7 @@ class Choice(models.TextChoices):
     A = "a", "A description"
     B = "b", "B description"
     C = "c", gettext_lazy("C description")
+    D = "12d-d'éléphant_🐘", "D description"
 
 
 class IntegerChoice(models.IntegerChoices):
@@ -113,6 +114,7 @@ def test_choices_field():
       A
       B
       C
+      D
     }
 
     type ChoicesType {
@@ -259,6 +261,7 @@ def test_generate_choices_from_enum():
       A
       B
       C
+      D
     }
 
     type ChoicesType {
@@ -297,6 +300,9 @@ def test_generate_choices_from_enum():
 
       """C description"""
       c
+
+      """D description"""
+      _2d_d__l_phant__
     }
     '''
 
@@ -360,6 +366,7 @@ def test_generate_choices_from_enum_with_extra_fields():
       A
       B
       C
+      D
     }
 
     type ChoicesWithExtraFieldsType {
@@ -400,6 +407,9 @@ def test_generate_choices_from_enum_with_extra_fields():
 
       """C description"""
       c
+
+      """D description"""
+      _2d_d__l_phant__
     }
 
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -21,6 +21,7 @@ class Choice(models.TextChoices):
     B = "b", "B description"
     C = "c", gettext_lazy("C description")
     D = "12d-d'éléphant_🐘", "D description"
+    E = "_2d_d__l_phant__", "E description"
 
 
 class IntegerChoice(models.IntegerChoices):
@@ -115,6 +116,7 @@ def test_choices_field():
       B
       C
       D
+      E
     }
 
     type ChoicesType {
@@ -262,6 +264,7 @@ def test_generate_choices_from_enum():
       B
       C
       D
+      E
     }
 
     type ChoicesType {
@@ -303,6 +306,9 @@ def test_generate_choices_from_enum():
 
       """D description"""
       _2d_d__l_phant__
+
+      """E description"""
+      _2d_d__l_phant___
     }
     '''
 
@@ -367,6 +373,7 @@ def test_generate_choices_from_enum_with_extra_fields():
       B
       C
       D
+      E
     }
 
     type ChoicesWithExtraFieldsType {
@@ -410,6 +417,9 @@ def test_generate_choices_from_enum_with_extra_fields():
 
       """D description"""
       _2d_d__l_phant__
+
+      """E description"""
+      _2d_d__l_phant___
     }
 
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -4,6 +4,7 @@ from typing import cast
 import strawberry
 from django.db import models
 from django.test import override_settings
+from django.utils.translation import gettext_lazy
 from django_choices_field import IntegerChoicesField, TextChoicesField
 from pytest_mock import MockerFixture
 
@@ -18,7 +19,7 @@ class Choice(models.TextChoices):
 
     A = "a", "A description"
     B = "b", "B description"
-    C = "c", "C description"
+    C = "c", gettext_lazy("C description")
 
 
 class IntegerChoice(models.IntegerChoices):
@@ -26,7 +27,7 @@ class IntegerChoice(models.IntegerChoices):
 
     X = 1, "1 description"
     Y = 2, "2 description"
-    Z = 3, "3 description"
+    Z = 3, gettext_lazy("3 description")
 
 
 class ChoicesModel(models.Model):
@@ -36,13 +37,13 @@ class ChoicesModel(models.Model):
         max_length=255,
         choices=[
             ("c", "C description"),
-            ("d", "D description"),
+            ("d", gettext_lazy("D description")),
         ],
     )
     attr4 = models.IntegerField(
         choices=[
             (4, "4 description"),
-            (5, "5 description"),
+            (5, gettext_lazy("5 description")),
         ],
     )
     attr5 = models.CharField(
@@ -61,13 +62,13 @@ class ChoicesWithExtraFieldsModel(models.Model):
         max_length=255,
         choices=[
             ("c", "C description"),
-            ("d", "D description"),
+            ("d", gettext_lazy("D description")),
         ],
     )
     attr4 = models.IntegerField(
         choices=[
             (4, "4 description"),
-            (5, "5 description"),
+            (5, gettext_lazy("5 description")),
         ],
     )
     attr5 = models.CharField(


### PR DESCRIPTION
Use regex to replace invalid characters in auto generated enums.

This occur because django's choice values are strings and can contain any chars.

Exemple This
```
class Choice(models.TextChoices):
   EN_US = "en-US", "English"
```

`Choice.choices` return `(("en-US", "English"),)`, and hyphen is not a valid char for GraphQL naming convention. So it would fail.
The PR replace non valid chars to `_`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #489 
* #493

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
