### PR TITLE
fix: Add support for generated enums in mutation input

### DIFF
--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -172,6 +173,9 @@ def parse_input(info: Info, data: Any, *, key_attr: str | None = "pk"):
                 List[InputListTypes], parse_input(info, data.set, key_attr=key_attr)
             ),
         )
+
+    if isinstance(data, Enum):
+        return data.value
 
     if dataclasses.is_dataclass(data):
         return {

--- a/tests/test_input_mutations.py
+++ b/tests/test_input_mutations.py
@@ -380,7 +380,7 @@ def test_input_create_with_m2m_mutation(db, gql_client: GraphQLTestClient):
 @pytest.mark.django_db(transaction=True)
 def test_input_update_mutation(db, gql_client: GraphQLTestClient):
     query = """
-    mutation CreateIssue ($input: IssueInputPartial!) {
+    mutation UpdateIssue ($input: IssueInputPartial!) {
       updateIssue (input: $input) {
         __typename
         ... on OperationInfo {
@@ -473,7 +473,7 @@ def test_input_update_mutation(db, gql_client: GraphQLTestClient):
 @pytest.mark.django_db(transaction=True)
 def test_input_nested_update_mutation(db, gql_client: GraphQLTestClient):
     query = """
-    mutation CreateIssue ($input: IssueInputPartial!) {
+    mutation UpdateIssue ($input: IssueInputPartial!) {
       updateIssue (input: $input) {
         __typename
         ... on OperationInfo {
@@ -576,7 +576,7 @@ def test_input_update_m2m_set_not_null_mutation(db, gql_client: GraphQLTestClien
 @pytest.mark.django_db(transaction=True)
 def test_input_update_m2m_set_mutation(db, gql_client: GraphQLTestClient):
     query = """
-    mutation CreateIssue ($input: IssueInputPartial!) {
+    mutation UpdateIssue ($input: IssueInputPartial!) {
       updateIssue (input: $input) {
         __typename
         ... on OperationInfo {
@@ -701,7 +701,7 @@ def test_input_update_m2m_set_mutation(db, gql_client: GraphQLTestClient):
 @pytest.mark.django_db(transaction=True)
 def test_input_update_m2m_set_through_mutation(db, gql_client: GraphQLTestClient):
     query = """
-    mutation CreateIssue ($input: IssueInputPartial!) {
+    mutation UpdateIssue ($input: IssueInputPartial!) {
       updateIssue (input: $input) {
         __typename
         ... on OperationInfo {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
If `GENERATE_ENUMS_FROM_CHOICES` is set to `True`, mutations with enum input values will resolve the input type as an enum. When the input is parsed, it tries to save the field as an enum instead of a string value, causing Django to throw a ValidationError `"Value 'ExampleEnum.VALUE' is not a valid choice."`. This PR addresses this issue by parsing the enum and returning the enum value.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fix https://github.com/strawberry-graphql/strawberry-django/issues/491

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
