### PR TITLE
fix: async with new filter API (assert queryset is wrong)

### DIFF
--- a/strawberry_django/fields/filter_order.py
+++ b/strawberry_django/fields/filter_order.py
@@ -122,7 +122,7 @@ class FilterOrderFieldResolver(StrawberryResolver):
             kwargs[info_parameter.name] = info
 
         if info_parameter := self.reserved_parameters.get(QUERYSET_PARAMSPEC):
-            assert queryset
+            assert queryset is not None
             kwargs[info_parameter.name] = queryset
 
         if info_parameter := self.reserved_parameters.get(SEQUENCE_PARAMSPEC):

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -257,7 +257,7 @@ def test_resolver_filter(fruits):
     ]
 
 
-def test_empty_resolver_filter(fruits):
+def test_empty_resolver_filter():
     @strawberry.type
     class Query:
         @strawberry.field

--- a/tests/filters/test_filters_v2.py
+++ b/tests/filters/test_filters_v2.py
@@ -2,6 +2,7 @@
 from enum import Enum
 from typing import Any, List, Optional, cast
 
+import django
 import pytest
 import strawberry
 from django.db.models import Case, Count, Q, QuerySet, Value, When
@@ -9,6 +10,7 @@ from strawberry import auto
 from strawberry.exceptions import MissingArgumentsAnnotationsError
 from strawberry.relay import GlobalID
 from strawberry.type import WithStrawberryObjectDefinition, get_object_definition
+from strawberry.types import ExecutionResult
 
 import strawberry_django
 from strawberry_django.exceptions import (
@@ -380,3 +382,55 @@ def test_filter_distinct(query, db, fruits):
     """)
     assert not result.errors
     assert len(result.data["fruits"]) == 1
+
+
+def test_empty_resolver_filter(query):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def fruits(self, filters: FruitFilter) -> List[Fruit]:
+            queryset = models.Fruit.objects.none()
+            _info: Any = object()
+            return cast(
+                List[Fruit], strawberry_django.filters.apply(filters, queryset, _info)
+            )
+
+    query = utils.generate_query(Query)
+    result = query('{ fruits(filters: { name: { exact: "strawberry" } }) { id name } }')
+    assert isinstance(result, ExecutionResult)
+    assert not result.errors
+    assert result.data is not None
+    assert result.data["fruits"] == []
+
+
+@pytest.mark.asyncio()
+@pytest.mark.django_db(transaction=True)
+async def test_async_resolver_filter(fruits):
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def fruits(self, filters: FruitFilter) -> List[Fruit]:
+            queryset = models.Fruit.objects.all()
+            _info: Any = object()
+            queryset = strawberry_django.filters.apply(filters, queryset, _info)
+            if django.VERSION < (4, 1):
+                from asgiref.sync import sync_to_async
+
+                @sync_to_async
+                def helper():
+                    return cast(List[Fruit], list(queryset))
+
+                return await helper()
+            # cast fixes funny typing issue between list and List
+            return cast(List[Fruit], [fruit async for fruit in queryset])
+
+    query = utils.generate_query(Query)
+    result = await query(  # type: ignore
+        '{ fruits(filters: { name: { exact: "strawberry" } }) { id name } }'
+    )
+    assert isinstance(result, ExecutionResult)
+    assert not result.errors
+    assert result.data is not None
+    assert result.data["fruits"] == [
+        {"id": "1", "name": "strawberry"},
+    ]

--- a/tests/filters/test_filters_v2.py
+++ b/tests/filters/test_filters_v2.py
@@ -384,7 +384,7 @@ def test_filter_distinct(query, db, fruits):
     assert len(result.data["fruits"]) == 1
 
 
-def test_empty_resolver_filter(query):
+def test_empty_resolver_filter():
     @strawberry.type
     class Query:
         @strawberry.field

--- a/tests/filters/test_filters_v2.py
+++ b/tests/filters/test_filters_v2.py
@@ -396,7 +396,7 @@ def test_empty_resolver_filter(query):
             )
 
     query = utils.generate_query(Query)
-    result = query('{ fruits(filters: { name: { exact: "strawberry" } }) { id name } }')
+    result = query('{ fruits(filters: { name: { exact: "strawberry" } }) { name } }')
     assert isinstance(result, ExecutionResult)
     assert not result.errors
     assert result.data is not None
@@ -426,11 +426,11 @@ async def test_async_resolver_filter(fruits):
 
     query = utils.generate_query(Query)
     result = await query(  # type: ignore
-        '{ fruits(filters: { name: { exact: "strawberry" } }) { id name } }'
+        '{ fruits(filters: { name: { exact: "strawberry" } }) { name } }'
     )
     assert isinstance(result, ExecutionResult)
     assert not result.errors
     assert result.data is not None
     assert result.data["fruits"] == [
-        {"id": "1", "name": "strawberry"},
+        {"name": "strawberry"},
     ]


### PR DESCRIPTION
This PR fixes a problem with the new filter API in async environments
It is likely a typo

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
