### PR TITLE
fix(optimizer): handle existing select_related in querysets

### DIFF
--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -304,9 +304,9 @@ class OptimizerStore:
             return fields
 
         if isinstance(qs.query.select_related, dict):
-            select_related_set.update(get_related_fields_with_prefix(
-                qs.query.select_related
-            ))
+            select_related_set.update(
+                get_related_fields_with_prefix(qs.query.select_related)
+            )
 
         if config.enable_select_related and select_related_set:
             qs = qs.select_related(*select_related_set)

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -242,6 +242,15 @@ class TagType(relay.Node):
     name: strawberry.auto
     issues: ListConnectionWithTotalCount[IssueType] = strawberry_django.connection()
 
+    @strawberry_django.field
+    def issues_with_selected_related_milestone_and_project(self) -> List[IssueType]:
+        # here, the `select_related` is on the queryset directly, and not on the field
+        return (
+            self.issues.all()  # type: ignore
+            .select_related("milestone", "milestone__project")
+            .order_by("id")
+        )
+
 
 @strawberry_django.type(Quiz)
 class QuizType(relay.Node):

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -889,6 +889,7 @@ type TagType implements Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): IssueTypeConnection!
+  issuesWithSelectedRelatedMilestoneAndProject: [IssueType!]!
 }
 
 """A connection to a list of items."""

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -377,6 +377,7 @@ type TagType implements Node {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): IssueTypeConnection!
+  issuesWithSelectedRelatedMilestoneAndProject: [IssueType!]!
 }
 
 type UserType implements Node {


### PR DESCRIPTION
## Description

The strawberry-django optimizer can automatically add `select_related` and `only` clauses to a queryset. However, it currently fails if you enable the `only` optimization while using querysets that already have `select_related`s on them.

We use strawberry at work, and have a model like:
```
class MyManager(models.Manager):
  def get_queryset(self):
    return super().get_queryset().select_related("foo")

class MyModel(models.Model):
  objects = MyManager()
  foo = models.ForeignKey(Foo, on_delete=models.CASCADE)
```

This causes issues with the optimizer if you try to execute a graphQL query that *doesn't* include `foo`: you get errors like `Field cannot be both deferred and traversed using select_related at the same time`. We've actually been running without the `only` optimization for a long time for this reason.

This PR adds some code to the optimizer that inspects the queryset for any existing `select_related`s, and includes them in the `.only()` call.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

N/A, there's no issue for this, though it related to [this old message](https://discord.com/channels/689806334337482765/1045715992086593597/1045715992086593597) in the Strawberry Discord.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
