### PR TITLE
fix: Delete mutation should not throw error if no objects in filterset

### DIFF
--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -492,7 +492,6 @@ def delete(info: Info, instance: _M | Iterable[_M], *, data=None) -> _M | list[_
         many = False
         instances = [instance]
 
-    assert len({obj.__class__ for obj in instances}) == 1
     for instance in instances:
         pk = instance.pk
         instance.delete()

--- a/tests/mutations/test_filter_mutations.py
+++ b/tests/mutations/test_filter_mutations.py
@@ -1,0 +1,67 @@
+"""Tests for "batch mutations", mutations with a filter function that return a list."""
+
+
+def test_delete_with_filter(mutation, fruits):
+    result = mutation(
+        """
+        {
+          fruits: deleteFruits(
+            filters: {id: {exact: 1}}
+          ) {
+            id
+            name
+          }
+        }
+        """
+    )
+    assert not result.errors
+
+
+def test_delete_with_filter_empty_list(mutation, fruits):
+    result = mutation(
+        """
+        {
+          fruits: deleteFruits(
+            filters: {id: {inList: []}}
+          ) {
+            id
+            name
+          }
+        }
+        """
+    )
+    assert not result.errors
+
+
+def test_update_with_filter(mutation, fruits):
+    result = mutation(
+        """
+        {
+          fruits: updateFruits(
+            data: { name: "orange" }
+            filters: {id: {exact: 1}}
+          ) {
+            id
+            name
+          }
+        }
+        """
+    )
+    assert not result.errors
+
+
+def test_update_with_filter_empty_list(mutation, fruits):
+    result = mutation(
+        """
+        {
+          fruits: updateFruits(
+            data: { name: "orange" }
+            filters: {id: {inList: []}}
+          ) {
+            id
+            name
+          }
+        }
+        """
+    )
+    assert not result.errors


### PR DESCRIPTION
## Description

When running a batched delete mutation, if no objects are in the filter set, the mutation should be no-op, and an empty array should be returned. This matches the behavior of a batched update and also ensures idempotence.

Current behavior: An empty set throws an error
Expected behavior: An empty set does not throw an error

Scope of change: 
- Remove a seemingly necessary assert statement. 
- Add some tests (including a breaking test)


## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR
n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
