### PR TITLE
feat: Nested optimization for lists and connections

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,6 @@ jobs:
       fail-fast: false
       matrix:
         django-version:
-          - 3.2.*
-          - 4.0.*
-          - 4.1.*
           - 4.2.*
           - 5.0.*
         python-version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Framework :: Django",
-  "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4.0",
-  "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
 ]

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -36,7 +36,7 @@ from strawberry_django.arguments import argument
 from strawberry_django.descriptors import ModelProperty
 from strawberry_django.fields.base import StrawberryDjangoFieldBase
 from strawberry_django.filters import FILTERS_ARG, StrawberryDjangoFieldFilters
-from strawberry_django.optimizer import OptimizerStore
+from strawberry_django.optimizer import OptimizerStore, is_optimized_by_prefetching
 from strawberry_django.ordering import ORDER_ARG, StrawberryDjangoFieldOrdering
 from strawberry_django.pagination import StrawberryDjangoPagination
 from strawberry_django.permissions import filter_with_perms
@@ -46,6 +46,7 @@ from strawberry_django.resolvers import (
     default_qs_hook,
     django_getattr,
     django_resolver,
+    resolve_base_manager,
 )
 
 if TYPE_CHECKING:
@@ -222,7 +223,7 @@ class StrawberryDjangoField(
                 resolved = await result  # type: ignore
 
                 if isinstance(resolved, BaseManager):
-                    resolved = resolved.all()
+                    resolved = resolve_base_manager(resolved)
 
                 if isinstance(resolved, models.QuerySet):
                     if "info" not in kwargs:
@@ -237,7 +238,7 @@ class StrawberryDjangoField(
             return async_resolver()
 
         if isinstance(result, BaseManager):
-            result = result.all()
+            result = resolve_base_manager(result)
 
         if isinstance(result, models.QuerySet):
             if "info" not in kwargs:
@@ -279,6 +280,11 @@ class StrawberryDjangoField(
         return qs_hook
 
     def get_queryset(self, queryset, info, **kwargs):
+        # If the queryset been optimized at prefetch phase, this function has already been
+        # called by the optimizer extension, meaning we don't want to call it again
+        if is_optimized_by_prefetching(queryset):
+            return queryset
+
         queryset = run_type_get_queryset(queryset, self.django_type, info)
         queryset = super().get_queryset(
             filter_with_perms(queryset, info), info, **kwargs

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -18,7 +18,6 @@ from typing import (
     Union,
 )
 
-import django
 import strawberry
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Field, Model, fields
@@ -239,6 +238,7 @@ field_type_map: Dict[
     fields.IntegerField: int,
     fields.PositiveIntegerField: int,
     fields.PositiveSmallIntegerField: int,
+    fields.PositiveBigIntegerField: int,
     fields.SlugField: str,
     fields.SmallAutoField: strawberry.ID,
     fields.SmallIntegerField: int,
@@ -246,6 +246,7 @@ field_type_map: Dict[
     fields.TimeField: datetime.time,
     fields.URLField: str,
     fields.UUIDField: uuid.UUID,
+    json.JSONField: JSON,
     files.FileField: DjangoFileType,
     files.ImageField: DjangoImageType,
     related.ForeignKey: DjangoModelType,
@@ -255,18 +256,6 @@ field_type_map: Dict[
     reverse_related.ManyToOneRel: List[DjangoModelType],
     reverse_related.OneToOneRel: DjangoModelType,
 }
-
-if hasattr(fields, "NullBooleanField"):
-    # NullBooleanField was deprecated and will soon be removed
-    field_type_map[fields.NullBooleanField] = Optional[bool]  # type: ignore
-
-if django.VERSION >= (3, 1):
-    field_type_map.update(
-        {
-            json.JSONField: JSON,
-            fields.PositiveBigIntegerField: int,
-        },
-    )
 
 try:
     from django.contrib.gis import geos

--- a/strawberry_django/queryset.py
+++ b/strawberry_django/queryset.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import dataclasses
-from typing import Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from django.db.models import Model
 from django.db.models.query import QuerySet
-from strawberry import Info
+
+if TYPE_CHECKING:
+    from strawberry import Info
 
 _M = TypeVar("_M", bound=Model)
 
@@ -23,7 +27,7 @@ def get_queryset_config(queryset: QuerySet) -> StrawberryDjangoQuerySetConfig:
 def run_type_get_queryset(
     qs: QuerySet[_M],
     origin: Any,
-    info: Optional[Info] = None,
+    info: Info | None = None,
 ) -> QuerySet[_M]:
     config = get_queryset_config(qs)
     get_queryset = getattr(origin, "get_queryset", None)

--- a/tests/fields/test_input.py
+++ b/tests/fields/test_input.py
@@ -11,12 +11,6 @@ class InputFieldsModel(models.Model):
     default = models.IntegerField(default=1)
     blank = models.IntegerField(blank=True)
     null = models.IntegerField(null=True)
-    # NullBoleanField is deprecated and will be removed in Django 5.0
-    null_boolean = (
-        models.NullBooleanField()  # type: ignore
-        if hasattr(models, "NullBooleanField")
-        else models.BooleanField(null=True)
-    )
 
 
 def test_input_type():
@@ -27,7 +21,6 @@ def test_input_type():
         default: auto
         blank: auto
         null: auto
-        null_boolean: auto
 
     assert [
         (f.name, f.type) for f in get_object_definition(InputType, strict=True).fields
@@ -37,7 +30,6 @@ def test_input_type():
         ("default", StrawberryOptional(int)),
         ("blank", StrawberryOptional(int)),
         ("null", StrawberryOptional(int)),
-        ("null_boolean", StrawberryOptional(bool)),
     ]
 
 
@@ -49,7 +41,6 @@ def test_input_type_for_partial_update():
         default: auto
         blank: auto
         null: auto
-        null_boolean: auto
 
     assert [
         (f.name, f.type) for f in get_object_definition(InputType, strict=True).fields
@@ -59,7 +50,6 @@ def test_input_type_for_partial_update():
         ("default", StrawberryOptional(int)),
         ("blank", StrawberryOptional(int)),
         ("null", StrawberryOptional(int)),
-        ("null_boolean", StrawberryOptional(bool)),
     ]
 
 

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -36,12 +36,6 @@ class FieldTypesModel(models.Model):
     generic_ip_address = models.GenericIPAddressField()
     integer = models.IntegerField()
     image = models.ImageField()
-    # NullBooleanField was deprecated and will soon be removed
-    null_boolean = (
-        models.NullBooleanField()  # type: ignore
-        if hasattr(models, "NullBooleanField")
-        else models.BooleanField(null=True)
-    )
     positive_big_integer = models.PositiveBigIntegerField()
     positive_integer = models.PositiveIntegerField()
     positive_small_integer = models.PositiveSmallIntegerField()
@@ -86,7 +80,6 @@ def test_field_types():
         generic_ip_address: auto
         integer: auto
         image: auto
-        null_boolean: auto
         positive_big_integer: auto
         positive_integer: auto
         positive_small_integer: auto
@@ -113,7 +106,6 @@ def test_field_types():
         ("generic_ip_address", str),
         ("integer", int),
         ("image", strawberry_django.DjangoImageType),
-        ("null_boolean", StrawberryOptional(bool)),
         ("positive_big_integer", int),
         ("positive_integer", int),
         ("positive_small_integer", int),

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -2,7 +2,6 @@ import textwrap
 from enum import Enum
 from typing import Generic, List, Optional, TypeVar, cast
 
-import django
 import pytest
 import strawberry
 from django.test import override_settings
@@ -282,14 +281,6 @@ async def test_async_resolver_filter(fruits):
         async def fruits(self, filters: FruitFilter) -> List[Fruit]:
             queryset = models.Fruit.objects.all()
             queryset = strawberry_django.filters.apply(filters, queryset)
-            if django.VERSION < (4, 1):
-                from asgiref.sync import sync_to_async
-
-                @sync_to_async
-                def helper():
-                    return cast(List[Fruit], list(queryset))
-
-                return await helper()
             # cast fixes funny typing issue between list and List
             return cast(List[Fruit], [fruit async for fruit in queryset])
 
@@ -300,9 +291,8 @@ async def test_async_resolver_filter(fruits):
     assert isinstance(result, ExecutionResult)
     assert not result.errors
     assert result.data is not None
-    assert result.data["fruits"] == [
-        {"id": "1", "name": "strawberry"},
-    ]
+    assert len(result.data["fruits"]) == 1
+    assert result.data["fruits"][0]["name"] == "strawberry"
 
 
 def test_resolver_filter_with_inheritance(vegetables):

--- a/tests/filters/test_filters_v2.py
+++ b/tests/filters/test_filters_v2.py
@@ -2,7 +2,6 @@
 from enum import Enum
 from typing import Any, List, Optional, cast
 
-import django
 import pytest
 import strawberry
 from django.db.models import Case, Count, Q, QuerySet, Value, When
@@ -448,14 +447,6 @@ async def test_async_resolver_filter(fruits):
             queryset = models.Fruit.objects.all()
             _info: Any = object()
             queryset = strawberry_django.filters.apply(filters, queryset, _info)
-            if django.VERSION < (4, 1):
-                from asgiref.sync import sync_to_async
-
-                @sync_to_async
-                def helper():
-                    return cast(List[Fruit], list(queryset))
-
-                return await helper()
             # cast fixes funny typing issue between list and List
             return cast(List[Fruit], [fruit async for fruit in queryset])
 

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -241,6 +241,7 @@ input IssueAssigneeInputPartialListInput {
 }
 
 input IssueFilter {
+  name: StrFilterLookup
   AND: IssueFilter
   OR: IssueFilter
   NOT: IssueFilter
@@ -278,6 +279,10 @@ input IssueInputPartialWithoutId {
   extra: Int
   assignees: AssigneeInputPartialListInput
   issueAssignees: IssueAssigneeInputPartialListInput
+}
+
+input IssueOrder {
+  name: Ordering
 }
 
 type IssueType implements Node {
@@ -366,7 +371,7 @@ type MilestoneType implements Node {
   name: String!
   dueDate: Date
   project: ProjectType!
-  issues: [IssueType!]!
+  issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
   myIssues: [IssueType!]!
   issuesWithFilters(
     filters: IssueFilter

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -64,6 +64,7 @@ The `ID` scalar type represents a unique identifier, often used to refetch an ob
 scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
 
 input IssueFilter {
+  name: StrFilterLookup
   AND: IssueFilter
   OR: IssueFilter
   NOT: IssueFilter
@@ -78,6 +79,10 @@ input IssueInputSubclass {
   kind: String
   tags: [NodeInput!]
   extra: Int
+}
+
+input IssueOrder {
+  name: Ordering
 }
 
 type IssueType implements Node {
@@ -156,7 +161,7 @@ type MilestoneType implements Node {
   name: String!
   dueDate: Date
   project: ProjectType!
-  issues: [IssueType!]!
+  issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
   myIssues: [IssueType!]!
   issuesWithFilters(
     filters: IssueFilter
@@ -183,7 +188,7 @@ type MilestoneTypeSubclass implements Node {
   name: String!
   dueDate: Date
   project: ProjectType!
-  issues: [IssueType!]!
+  issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
   myIssues: [IssueType!]!
   issuesWithFilters(
     filters: IssueFilter
@@ -217,6 +222,11 @@ interface Node {
 """Input of an object that implements the `Node` interface."""
 input NodeInput {
   id: GlobalID!
+}
+
+input OffsetPaginationInput {
+  offset: Int! = 0
+  limit: Int! = -1
 }
 
 type OperationInfo {


### PR DESCRIPTION
This is going to enable optimization of nested relations even when using filters/ordering/pagination, which previously would mean throwing the results away and fetching new ones, causing more than n+1 issues.

Note: Although nested connections are being optimized as well, we are only doing that for those annotated with `ListConnection` and `ListConnectionWithTotalCount`, as custom connections may contain more complex code which are not safe to be optimized the way we are doing here.

We are also dropping support for Django versions older than 4.2 as we cannot filter over window functions in older versions. That is also a recommendation from Django itself when 5.0 was released: https://docs.djangoproject.com/en/5.0/releases/5.0

Fix #337
Fix #340
Fix #345
Fix #389
Fix #521
