### PR TITLE
fix: fix optimized nested connections failing to access totalCount

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -374,6 +374,40 @@ files = [
 Django = ">=2.2"
 
 [[package]]
+name = "django-js-asset"
+version = "2.2.0"
+description = "script tag with additional attributes for django.forms.Media"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_js_asset-2.2.0-py3-none-any.whl", hash = "sha256:7ef3e858e13d06f10799b56eea62b1e76706f42cf4e709be4e13356bc0ae30d8"},
+    {file = "django_js_asset-2.2.0.tar.gz", hash = "sha256:0c57a82cae2317e83951d956110ce847f58ff0cdc24e314dbc18b35033917e94"},
+]
+
+[package.dependencies]
+django = ">=3.2"
+
+[package.extras]
+tests = ["coverage"]
+
+[[package]]
+name = "django-mptt"
+version = "0.14.0"
+description = "Utilities for implementing Modified Preorder Tree Traversal with your Django Models and working with trees of Model instances."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "django-mptt-0.14.0.tar.gz", hash = "sha256:2c92a2b1614c53086278795ccf50580cf1f9b8564f3ff03055dd62bab5987711"},
+    {file = "django_mptt-0.14.0-py3-none-any.whl", hash = "sha256:d9a87433ab0e4f35247c6f6d5a93ace6990860a4ba8796f815d185f773b9acfc"},
+]
+
+[package.dependencies]
+django-js-asset = "*"
+
+[package.extras]
+tests = ["coverage", "mock-django"]
+
+[[package]]
 name = "django-types"
 version = "0.19.1"
 description = "Type stubs for Django"
@@ -1195,7 +1229,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1579,4 +1612,4 @@ enum = ["django-choices-field"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "572932285726563d31fe77f88a0ce9799811a97bc097eb58e93ba8622d9e0d6a"
+content-hash = "318e9050ee132d42514886e0e9dbc771693743564cc8d974c70055e78d682f7d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ channels = { version = ">=3.0.5" }
 django-choices-field = "^2.2.2"
 django-debug-toolbar = "^4.2.0"
 django-guardian = "^2.4.0"
+django-mptt = "^0.14.0"
 django-types = "^0.19.1"
 factory-boy = "^3.2.1"
 mkdocs = "^1.4.2"

--- a/strawberry_django/relay.py
+++ b/strawberry_django/relay.py
@@ -102,7 +102,7 @@ class ListConnectionWithTotalCount(relay.ListConnection[relay.NodeType]):
 
         if isinstance(nodes, models.QuerySet) and is_optimized_by_prefetching(nodes):
             try:
-                return cls.resolve_connection_from_cache(
+                conn = cls.resolve_connection_from_cache(
                     nodes,
                     info=info,
                     before=before,
@@ -120,6 +120,10 @@ class ListConnectionWithTotalCount(relay.ListConnection[relay.NodeType]):
                     RuntimeWarning,
                     stacklevel=2,
                 )
+            else:
+                conn = cast(Self, conn)
+                conn.nodes = nodes
+                return conn
 
         conn = super().resolve_connection(
             nodes,

--- a/tests/relay/mptt/a.py
+++ b/tests/relay/mptt/a.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING
+
+import strawberry
+from strawberry import relay
+from typing_extensions import Annotated, TypeAlias
+
+import strawberry_django
+from strawberry_django.relay import ListConnectionWithTotalCount
+
+from .models import MPTTAuthor
+
+if TYPE_CHECKING:
+    from .b import MPTTBookConnection
+
+
+@strawberry_django.type(MPTTAuthor)
+class MPTTAuthorType(relay.Node):
+    name: str
+    books: Annotated["MPTTBookConnection", strawberry.lazy("tests.relay.mptt.b")] = (
+        strawberry_django.connection()
+    )
+    children: "MPTTAuthorConnection" = strawberry_django.connection()
+
+
+MPTTAuthorConnection: TypeAlias = ListConnectionWithTotalCount[MPTTAuthorType]

--- a/tests/relay/mptt/b.py
+++ b/tests/relay/mptt/b.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING
+
+import strawberry
+from strawberry import relay
+from typing_extensions import Annotated, TypeAlias
+
+import strawberry_django
+from strawberry_django.relay import ListConnectionWithTotalCount
+
+from .models import MPTTBook
+
+if TYPE_CHECKING:
+    from .a import MPTTAuthorType
+
+
+@strawberry_django.filter(MPTTBook)
+class MPTTBookFilter:
+    name: str
+
+
+@strawberry_django.order(MPTTBook)
+class MPTTBookOrder:
+    name: str
+
+
+@strawberry_django.type(MPTTBook, filters=MPTTBookFilter, order=MPTTBookOrder)
+class MPTTBookType(relay.Node):
+    name: str
+    author: Annotated["MPTTAuthorType", strawberry.lazy("tests.relay.mptt.a")]
+
+
+MPTTBookConnection: TypeAlias = ListConnectionWithTotalCount[MPTTBookType]

--- a/tests/relay/mptt/models.py
+++ b/tests/relay/mptt/models.py
@@ -1,0 +1,23 @@
+from django.db import models
+from mptt.fields import TreeForeignKey
+from mptt.models import MPTTModel
+
+
+class MPTTAuthor(MPTTModel):
+    name = models.CharField(max_length=100)
+    parent = TreeForeignKey(
+        to="self",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="children",
+    )
+
+
+class MPTTBook(models.Model):
+    title = models.CharField(max_length=100)
+    author = models.ForeignKey(
+        MPTTAuthor,
+        on_delete=models.CASCADE,
+        related_name="books",
+    )

--- a/tests/relay/mptt/snapshots/test_lazy_annotations/test_lazy_type_annotations_in_schema/authors_and_books_schema.gql
+++ b/tests/relay/mptt/snapshots/test_lazy_annotations/test_lazy_type_annotations_in_schema/authors_and_books_schema.gql
@@ -1,0 +1,182 @@
+"""
+The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+"""
+scalar GlobalID @specifiedBy(url: "https://relay.dev/graphql/objectidentification.htm")
+
+type MPTTAuthorType implements Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+  name: String!
+  books(
+    filters: MPTTBookFilter
+    order: MPTTBookOrder
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MPTTBookTypeConnection!
+  children(
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MPTTAuthorTypeConnection!
+}
+
+"""A connection to a list of items."""
+type MPTTAuthorTypeConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [MPTTAuthorTypeEdge!]!
+
+  """Total quantity of existing nodes."""
+  totalCount: Int
+}
+
+"""An edge in a connection."""
+type MPTTAuthorTypeEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: MPTTAuthorType!
+}
+
+input MPTTBookFilter {
+  name: String!
+  AND: MPTTBookFilter
+  OR: MPTTBookFilter
+  NOT: MPTTBookFilter
+  DISTINCT: Boolean
+}
+
+input MPTTBookOrder {
+  name: String
+}
+
+type MPTTBookType implements Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+  name: String!
+  author: MPTTAuthorType!
+}
+
+"""A connection to a list of items."""
+type MPTTBookTypeConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [MPTTBookTypeEdge!]!
+
+  """Total quantity of existing nodes."""
+  totalCount: Int
+}
+
+"""An edge in a connection."""
+type MPTTBookTypeEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: MPTTBookType!
+}
+
+"""An object with a Globally Unique ID"""
+interface Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+}
+
+"""Information to aid in pagination."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+}
+
+type Query {
+  booksConn(
+    filters: MPTTBookFilter
+    order: MPTTBookOrder
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MPTTBookTypeConnection!
+  booksConn2(
+    filters: MPTTBookFilter
+    order: MPTTBookOrder
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MPTTBookTypeConnection!
+  authorsConn(
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MPTTAuthorTypeConnection!
+  authorsConn2(
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MPTTAuthorTypeConnection!
+}

--- a/tests/relay/mptt/test_lazy_annotations.py
+++ b/tests/relay/mptt/test_lazy_annotations.py
@@ -1,0 +1,28 @@
+import pathlib
+
+import strawberry
+from pytest_snapshot.plugin import Snapshot
+
+import strawberry_django
+from strawberry_django.relay import ListConnectionWithTotalCount
+
+from .a import MPTTAuthorConnection, MPTTAuthorType
+from .b import MPTTBookConnection, MPTTBookType
+
+SNAPSHOTS_DIR = pathlib.Path(__file__).parent / "snapshots"
+
+
+def test_lazy_type_annotations_in_schema(snapshot: Snapshot):
+    @strawberry.type
+    class Query:
+        books_conn: MPTTBookConnection = strawberry_django.connection()
+        books_conn2: ListConnectionWithTotalCount[MPTTBookType] = (
+            strawberry_django.connection()
+        )
+        authors_conn: MPTTAuthorConnection = strawberry_django.connection()
+        authors_conn2: ListConnectionWithTotalCount[MPTTAuthorType] = (
+            strawberry_django.connection()
+        )
+
+    schema = strawberry.Schema(query=Query)
+    snapshot.assert_match(str(schema), "authors_and_books_schema.gql")

--- a/tests/relay/mptt/test_nested_children.py
+++ b/tests/relay/mptt/test_nested_children.py
@@ -1,0 +1,47 @@
+import pytest
+import strawberry
+
+import strawberry_django
+from strawberry_django.optimizer import DjangoOptimizerExtension
+
+from .a import MPTTAuthorConnection
+from .models import MPTTAuthor
+
+
+@strawberry.type
+class Query:
+    authors: MPTTAuthorConnection = strawberry_django.connection()
+
+
+schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
+
+
+@pytest.mark.django_db(transaction=True)
+def test_nested_children_total_count():
+    parent = MPTTAuthor.objects.create(name="Parent")
+    MPTTAuthor.objects.create(name="Child", parent=parent)
+    query = """\
+    query {
+      authors(last: 1) {
+        totalCount
+        edges {
+          node {
+            id
+            name
+            children {
+              totalCount
+              edges {
+                node {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    result = schema.execute_sync(query)
+    assert not result.errors


### PR DESCRIPTION
When resolving the connection from cache, we were missing setting `nodes` in it 🤦‍♂️

We do have a test that was passing with this, but MPTT triggered the issue. The issue was probably happening to corner cases as well

Used https://github.com/strawberry-graphql/strawberry-django/pull/551 as a base for the reproduction, but adjusted it to avoid depending on python 3.9

Fix https://github.com/strawberry-graphql/strawberry-django/issues/552