### PR TITLE
fix: Extract interface definition in optimizer to fix django-polymorphic

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -408,6 +408,20 @@ django-js-asset = "*"
 tests = ["coverage", "mock-django"]
 
 [[package]]
+name = "django-polymorphic"
+version = "3.1.0"
+description = "Seamless polymorphic inheritance for Django models"
+optional = false
+python-versions = "*"
+files = [
+    {file = "django-polymorphic-3.1.0.tar.gz", hash = "sha256:d6955b5308bf6e41dcb22ba7c96f00b51dfa497a8a5ab1e9c06c7951bf417bf8"},
+    {file = "django_polymorphic-3.1.0-py3-none-any.whl", hash = "sha256:08bc4f4f4a773a19b2deced5a56deddd1ef56ebd15207bf4052e2901c25ef57e"},
+]
+
+[package.dependencies]
+Django = ">=2.1"
+
+[[package]]
 name = "django-types"
 version = "0.19.1"
 description = "Type stubs for Django"
@@ -1229,6 +1243,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1411,6 +1426,21 @@ files = [
     {file = "ruff-0.4.4-py3-none-win_arm64.whl", hash = "sha256:39df0537b47d3b597293edbb95baf54ff5b49589eb7ff41926d8243caa995ea6"},
     {file = "ruff-0.4.4.tar.gz", hash = "sha256:f87ea42d5cdebdc6a69761a9d0bc83ae9b3b30d0ad78952005ba6568d6c022af"},
 ]
+
+[[package]]
+name = "setuptools"
+version = "70.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
+    {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1612,4 +1642,4 @@ enum = ["django-choices-field"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "318e9050ee132d42514886e0e9dbc771693743564cc8d974c70055e78d682f7d"
+content-hash = "888fc6f103df2dcffa5dde4ef1f483e7988a86105c6f95294c8b38d44f53fb2f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1243,7 +1243,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ pytest-mock = "^3.5.1"
 pytest-snapshot = "^0.9.0"
 pytest-watch = "^4.2.0"
 ruff = "^0.4.1"
+django-polymorphic = "^3.1.0"
+setuptools = "^70.0.0"                                      # required by django-polymorphic
 
 [tool.poetry.extras]
 debug-toolbar = ["django-debug-toolbar"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ pytest-snapshot = "^0.9.0"
 pytest-watch = "^4.2.0"
 ruff = "^0.4.1"
 django-polymorphic = "^3.1.0"
-setuptools = "^70.0.0"                                      # required by django-polymorphic
+setuptools = "^70.0.0"
 
 [tool.poetry.extras]
 debug-toolbar = ["django-debug-toolbar"]

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -794,7 +794,7 @@ def _get_model_hints(
     return store
 
 
-def _get_gql_definition(schema: Schema, definition: StrawberryObjectDefinition):
+def _get_gql_definition(schema: Schema, definition: StrawberryObjectDefinition) -> Any:
     if definition.is_interface:
         return schema.schema_converter.from_interface(definition)
 
@@ -986,9 +986,11 @@ def mark_optimized_by_prefetching(qs: QuerySet[_M]) -> QuerySet[_M]:
     # This is a bit of a hack, but there is no easy way to mark a related manager
     # as optimized at this phase, so we just add a mark to the queryset that
     # we can check leater on using is_optimized_by_prefetching
-    return qs.annotate(**{
-        NESTED_PREFETCH_MARK: models.Value(True),
-    })
+    return qs.annotate(
+        **{
+            NESTED_PREFETCH_MARK: models.Value(True),
+        }
+    )
 
 
 def is_optimized_by_prefetching(qs: QuerySet) -> bool:

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -986,11 +986,9 @@ def mark_optimized_by_prefetching(qs: QuerySet[_M]) -> QuerySet[_M]:
     # This is a bit of a hack, but there is no easy way to mark a related manager
     # as optimized at this phase, so we just add a mark to the queryset that
     # we can check leater on using is_optimized_by_prefetching
-    return qs.annotate(
-        **{
-            NESTED_PREFETCH_MARK: models.Value(True),
-        }
-    )
+    return qs.annotate(**{
+        NESTED_PREFETCH_MARK: models.Value(True),
+    })
 
 
 def is_optimized_by_prefetching(qs: QuerySet) -> bool:

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -113,5 +113,6 @@ INSTALLED_APPS.extend(
     [
         "tests",
         "tests.projects",
+        "tests.polymorphism",
     ],
 )

--- a/tests/polymorphism/models.py
+++ b/tests/polymorphism/models.py
@@ -1,0 +1,14 @@
+from django.db import models
+from polymorphic.models import PolymorphicModel
+
+
+class Project(PolymorphicModel):
+    topic = models.CharField(max_length=30)
+
+
+class ArtProject(Project):
+    artist = models.CharField(max_length=30)
+
+
+class ResearchProject(Project):
+    supervisor = models.CharField(max_length=30)

--- a/tests/polymorphism/schema.py
+++ b/tests/polymorphism/schema.py
@@ -1,0 +1,35 @@
+from typing import List
+
+import strawberry
+
+import strawberry_django
+from strawberry_django.optimizer import DjangoOptimizerExtension
+
+from .models import ArtProject, Project, ResearchProject
+
+
+@strawberry_django.interface(Project)
+class ProjectType:
+    topic: strawberry.auto
+
+
+@strawberry_django.type(ArtProject)
+class ArtProjectType(ProjectType):
+    artist: strawberry.auto
+
+
+@strawberry_django.type(ResearchProject)
+class ResearchProjectType(ProjectType):
+    supervisor: strawberry.auto
+
+
+@strawberry.type
+class Query:
+    projects: List[ProjectType] = strawberry_django.field()
+
+
+schema = strawberry.Schema(
+    query=Query,
+    types=[ArtProjectType, ResearchProjectType],
+    extensions=[DjangoOptimizerExtension],
+)

--- a/tests/polymorphism/test_optimizer.py
+++ b/tests/polymorphism/test_optimizer.py
@@ -1,0 +1,38 @@
+import pytest
+
+from .models import ArtProject, ResearchProject
+from .schema import schema
+
+
+@pytest.mark.django_db(transaction=True)
+def test_polymorphic_interface_query():
+    ap = ArtProject.objects.create(topic="Art", artist="Artist")
+    rp = ResearchProject.objects.create(topic="Research", supervisor="Supervisor")
+
+    query = """\
+    query {
+      projects {
+        __typename
+        topic
+        ... on ArtProjectType {
+          artist
+        }
+        ... on ResearchProjectType {
+          supervisor
+        }
+      }
+    }
+    """
+
+    result = schema.execute_sync(query)
+    assert not result.errors
+    assert result.data == {
+        "projects": [
+            {"__typename": "ArtProjectType", "topic": ap.topic, "artist": ap.artist},
+            {
+                "__typename": "ResearchProjectType",
+                "topic": rp.topic,
+                "supervisor": rp.supervisor,
+            },
+        ]
+    }


### PR DESCRIPTION
## Description

Extracting GraphQL definition from a strawberry definition based on the type (interface or object type)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fix #550 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the optimizer by correctly extracting GraphQL definitions from Strawberry definitions, handling both interface and object types. It also includes a refactoring to improve code clarity and maintainability.

* **Bug Fixes**:
    - Fixed the extraction of GraphQL definitions from Strawberry definitions by correctly handling both interface and object types.
* **Enhancements**:
    - Refactored the optimizer code to use a new helper function `_get_gql_definition` for determining the GraphQL definition based on the type.

<!-- Generated by sourcery-ai[bot]: end summary -->