### PR TITLE
docs: Remove officially unmaintained project

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -4,7 +4,6 @@ Those are some community maintained projects worth mentioning:
 
 |                                             Project                                              |                                                         Description                                                         |
 | :----------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------: |
-|  [:material-github: strawberry-django-jwt](https://github.com/KundaPanda/strawberry-django-jwt)  |                            :material-information: JWT implementation with Strawberry and Django.                            |
 |  [:material-github: strawberry-django-auth](https://github.com/nrbnlulu/strawberry-django-auth)  |                          :material-information: Authentication System for Django using Strawberry.                          |
 | [:material-github: strawberry-django-extras](https://github.com/m4riok/strawberry-django-extras) | :material-information: JWT Authentication, Input validation and permissions, mutation hooks and deeply nested CUD mutations |
 


### PR DESCRIPTION
## Description

Removing a community package that is officially not supported anymore and itself refers to the another mentioned (and listed in the docs) package that includes JWT token management.

My personal suggestion would be to remove the stale package to prevent confusing and keep things clean and up to date.

## Types of Changes

- [x] Documentation

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the community projects documentation by removing the reference to the unmaintained 'strawberry-django-jwt' project to prevent confusion and keep the documentation up to date.

* **Documentation**:
    - Removed the reference to the unmaintained 'strawberry-django-jwt' project from the community projects documentation.

<!-- Generated by sourcery-ai[bot]: end summary -->