### PR TITLE
Generated fields type resolution

### DIFF
--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
+import django
 from django.db.models import ForeignKey
 from strawberry import LazyType, relay
 from strawberry.annotation import StrawberryAnnotation

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 _QS = TypeVar("_QS", bound="models.QuerySet")
 
 try:
-    from django.db.models.fields.generated import GeneratedField
+    from django.db.models import GeneratedField  # type: ignore
 except ImportError:
     GeneratedField = None
 
@@ -207,7 +207,7 @@ class StrawberryDjangoFieldBase(StrawberryField):
                 self.origin_django_type,
             )
             if is_optional(
-                model_field.output_field
+                model_field.output_field  # type: ignore
                 if GeneratedField is not None
                 and isinstance(model_field, GeneratedField)
                 else model_field,

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -211,7 +211,7 @@ class StrawberryDjangoFieldBase(StrawberryField):
                 model_field, GeneratedField
             )
             field_to_check = (
-                model_field.output_field if is_generated_field else model_field
+                model_field.output_field if is_generated_field else model_field  # type: ignore
             )
             if is_optional(
                 field_to_check,

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -37,9 +37,9 @@ if TYPE_CHECKING:
 
 _QS = TypeVar("_QS", bound="models.QuerySet")
 
-try:
+if django.VERSION >= (5, 0):
     from django.db.models import GeneratedField  # type: ignore
-except ImportError:
+else:
     GeneratedField = None
 
 

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -37,6 +37,11 @@ if TYPE_CHECKING:
 
 _QS = TypeVar("_QS", bound="models.QuerySet")
 
+try:
+    from django.db.models.fields.generated import GeneratedField
+except ImportError:
+    GeneratedField = None
+
 
 class StrawberryDjangoFieldBase(StrawberryField):
     def __init__(
@@ -202,7 +207,10 @@ class StrawberryDjangoFieldBase(StrawberryField):
                 self.origin_django_type,
             )
             if is_optional(
-                model_field,
+                model_field.output_field
+                if GeneratedField is not None
+                and isinstance(model_field, GeneratedField)
+                else model_field,
                 self.origin_django_type.is_input,
                 self.origin_django_type.is_partial,
             ):

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -206,11 +206,15 @@ class StrawberryDjangoFieldBase(StrawberryField):
                 ),
                 self.origin_django_type,
             )
+
+            is_generated_field = GeneratedField is not None and isinstance(
+                model_field, GeneratedField
+            )
+            field_to_check = (
+                model_field.output_field if is_generated_field else model_field
+            )
             if is_optional(
-                model_field.output_field  # type: ignore
-                if GeneratedField is not None
-                and isinstance(model_field, GeneratedField)
-                else model_field,
+                field_to_check,
                 self.origin_django_type.is_input,
                 self.origin_django_type.is_partial,
             ):

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -38,6 +38,11 @@ except ImportError:  # pragma: no cover
     IntegerChoicesField = None
     TextChoicesField = None
 
+try:
+    from django.db.models.fields.generated import GeneratedField
+except ImportError:
+    GeneratedField = None
+
 if TYPE_CHECKING:
     from strawberry_django.type import StrawberryDjangoDefinition
 
@@ -469,6 +474,10 @@ def resolve_model_field_type(
                 ),
             )
             model_field._strawberry_enum = field_type  # type: ignore
+    # Generated fields
+    elif GeneratedField is not None and isinstance(model_field, GeneratedField):
+        model_field_type = type(model_field.output_field)
+        field_type = field_type_map.get(model_field_type, NotImplemented)
     # Every other Field possibility
     else:
         force_global_id = settings["MAP_AUTO_ID_AS_GLOBAL_ID"]

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
 )
 
+import django
 import strawberry
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Field, Model, fields
@@ -38,10 +39,11 @@ except ImportError:  # pragma: no cover
     IntegerChoicesField = None
     TextChoicesField = None
 
-try:
-    from django.db.models import GeneratedField  # type: ignore
-except ImportError:
+if django.VERSION >= (5, 0):
+    from django.db.models import GeneratedField
+else:
     GeneratedField = None
+
 
 if TYPE_CHECKING:
     from strawberry_django.type import StrawberryDjangoDefinition

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -39,7 +39,7 @@ except ImportError:  # pragma: no cover
     TextChoicesField = None
 
 try:
-    from django.db.models.fields.generated import GeneratedField
+    from django.db.models import GeneratedField  # type: ignore
 except ImportError:
     GeneratedField = None
 
@@ -476,7 +476,7 @@ def resolve_model_field_type(
             model_field._strawberry_enum = field_type  # type: ignore
     # Generated fields
     elif GeneratedField is not None and isinstance(model_field, GeneratedField):
-        model_field_type = type(model_field.output_field)
+        model_field_type = type(model_field.output_field)  # type: ignore
         field_type = field_type_map.get(model_field_type, NotImplemented)
     # Every other Field possibility
     else:

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     TextChoicesField = None
 
 if django.VERSION >= (5, 0):
-    from django.db.models import GeneratedField
+    from django.db.models import GeneratedField  # type: ignore
 else:
     GeneratedField = None
 

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -21,7 +21,7 @@ from strawberry.type import (
 
 import strawberry_django
 from strawberry_django.fields.field import StrawberryDjangoField
-from strawberry_django.type import _process_type
+from strawberry_django.type import _process_type  # noqa: PLC2701
 
 try:
     from django.db.models import GeneratedField  # type: ignore

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -4,6 +4,7 @@ import enum
 import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
+import django
 import pytest
 import strawberry
 from django.conf import settings
@@ -141,7 +142,7 @@ def test_field_types():
         ("json", JSON),
     ]
 
-    if hasattr(models, "GeneratedField"):
+    if django.VERSION >= (5, 0):
         Type.__annotations__["generated_decimal"] = auto
         expected_types.append(("generated_decimal", decimal.Decimal))
 

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -2,7 +2,7 @@ import datetime
 import decimal
 import enum
 import uuid
-from typing import cast, Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 import pytest
 import strawberry

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -24,9 +24,9 @@ import strawberry_django
 from strawberry_django.fields.field import StrawberryDjangoField
 from strawberry_django.type import _process_type  # noqa: PLC2701
 
-try:
+if django.VERSION >= (5, 0):
     from django.db.models import GeneratedField  # type: ignore
-except ImportError:
+else:
     GeneratedField = None
 
 

--- a/tests/fields/test_types.py
+++ b/tests/fields/test_types.py
@@ -2,7 +2,7 @@ import datetime
 import decimal
 import enum
 import uuid
-from typing import Dict, List, Tuple, Union, cast
+from typing import cast, Dict, List, Tuple, Union, Optional
 
 import pytest
 import strawberry
@@ -141,7 +141,7 @@ def test_field_types():
         expected_types.append(("generated_decimal", decimal.Decimal))
 
         Type.__annotations__["generated_nullable_decimal"] = auto
-        expected_types.append(("generated_nullable_decimal", decimal.Decimal | None))
+        expected_types.append(("generated_nullable_decimal", Optional[decimal.Decimal]))
 
     type_to_test = _process_type(Type, model=FieldTypesModel)
     object_definition = get_object_definition(type_to_test, strict=True)


### PR DESCRIPTION
I added support for field type resolution for Django 5 `GeneratedFields`. For a generated field, the `output_field` is mandatory, and this is what I'm using to determine the strawberry field type.

Extended existing test about field type resolution that is backwards compatible with Django <5. Did not modify the project dependencies.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces support for resolving field types for Django 5 `GeneratedFields` by utilizing the `output_field` attribute. It also extends existing tests to cover this new functionality while maintaining compatibility with earlier Django versions.

- **New Features**:
    - Added support for resolving field types for Django 5 `GeneratedFields` using the `output_field` attribute.
- **Enhancements**:
    - Extended existing tests to include field type resolution for `GeneratedFields`, ensuring backwards compatibility with Django versions prior to 5.

<!-- Generated by sourcery-ai[bot]: end summary -->