### PR TITLE
fix: Set files early on mutations to allow clean methods to validate them

### DIFF
--- a/tests/mutations/test_mutations.py
+++ b/tests/mutations/test_mutations.py
@@ -29,7 +29,7 @@ def test_create(mutation):
 
 
 def test_create_with_optional_file(mutation):
-    fname = "test_create_with_optional_fileb.png"
+    fname = "test_create_with_optional_file.png"
     upload = prep_image(fname)
     result = mutation(
         """\
@@ -52,6 +52,39 @@ def test_create_with_optional_file(mutation):
         "name": "strawberry",
         "picture": {"name": f".tmp_upload/{fname}"},
     }
+
+
+def test_update_with_optional_file_when_unsetting_it(mutation):
+    fname = "test_update_with_optional_file.png"
+    upload = prep_image(fname)
+    fruit = models.Fruit.objects.create(name="strawberry", picture=upload)
+
+    result = mutation(
+        """\
+        UpdateFruit($id: ID! $picture: Upload) {
+          updateFruits(
+            filters: { id: { exact: $id } }
+            data: { picture: $picture }
+          ) {
+            id
+            name
+            picture {
+              name
+            }
+          }
+        }
+        """,
+        variable_values={"id": fruit.pk, "picture": None},
+    )
+
+    assert not result.errors
+    assert result.data["updateFruits"] == [
+        {
+            "id": str(fruit.pk),
+            "name": "strawberry",
+            "picture": None,
+        }
+    ]
 
 
 def test_with_required_file_fails(mutation):


### PR DESCRIPTION
This is a regression from: https://github.com/strawberry-graphql/strawberry-django/pull/394

Fix https://github.com/strawberry-graphql/strawberry-django/issues/564

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a regression issue by ensuring files are set early in mutations to allow validation methods to function correctly. It also includes a new test to verify the update functionality when unsetting an optional file.

- **Bug Fixes**:
    - Fixed an issue where files were not set early enough in mutations, causing validation methods to fail.
- **Tests**:
    - Added a test to verify the update functionality when unsetting an optional file.

<!-- Generated by sourcery-ai[bot]: end summary -->