### PR TITLE
fix: Make sure the optimizer calls the type's `get_queryset` for nested lists/connections

### DIFF
--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -224,6 +224,7 @@ class IssueType(relay.Node, Named):
     name_with_kind: str = strawberry_django.field(only=["kind", "name"])
     tags: List["TagType"]
     issue_assignees: List["AssigneeType"]
+    staff_assignees: List["StaffType"] = strawberry_django.field(field_name="assignees")
     favorite_set: ListConnectionWithTotalCount["FavoriteType"] = (
         strawberry_django.connection()
     )

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -296,6 +296,7 @@ type IssueType implements Node & Named {
   nameWithKind: String!
   tags: [TagType!]!
   issueAssignees: [AssigneeType!]!
+  staffAssignees: [StaffType!]!
   favoriteSet(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -96,6 +96,7 @@ type IssueType implements Node & Named {
   nameWithKind: String!
   tags: [TagType!]!
   issueAssignees: [AssigneeType!]!
+  staffAssignees: [StaffType!]!
   favoriteSet(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null
@@ -324,6 +325,15 @@ type Query {
     """The ID of the object."""
     id: GlobalID!
   ): MilestoneTypeSubclass
+}
+
+type StaffType implements Node {
+  """The Globally Unique ID of this object"""
+  id: GlobalID!
+  email: String!
+  isActive: Boolean!
+  isSuperuser: Boolean!
+  isStaff: Boolean!
 }
 
 input StrFilterLookup {


### PR DESCRIPTION
Fix #562

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes an issue where the optimizer was not calling the type's `get_queryset` method for nested lists and connections. It also refactors the optimizer to use `_default_manager` for prefetching when `prefetch_custom_queryset` is enabled. Additionally, a new test is added to ensure the correct behavior.

- **Bug Fixes**:
    - Ensure the optimizer calls the type's `get_queryset` method for nested lists and connections.
- **Enhancements**:
    - Refactor the optimizer to use `_default_manager` for prefetching when `prefetch_custom_queryset` is enabled, otherwise use `_base_manager`.
- **Tests**:
    - Add a test to verify that the optimizer calls the type's `get_queryset` method for nested lists and connections.

<!-- Generated by sourcery-ai[bot]: end summary -->