### PR TITLE
fix(optimizer): Avoid extra queries for prefetches with existing prefetch hints

### DIFF
--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -800,9 +800,10 @@ def _get_hints_from_django_relation(
 
     field_store = getattr(field, "store", None)
     if field_store and field_store.prefetch_related:
-        # When we have a prefetch_related in the field, skip the optimization as
-        # it will probably be filtering/annotating the queryset differently, and doing
-        # it here would result in an extra unused query
+        # Skip optimization if 'prefetch_related' is present in the field's store.
+        # This is necessary because 'prefetch_related' likely modifies the queryset
+        # with filtering or annotating, making the optimization redundant and
+        # potentially causing an extra unused query.
         return store
 
     remote_field = model_field.remote_field

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -798,6 +798,13 @@ def _get_hints_from_django_relation(
         store.prefetch_related.append(model_fieldname)
         return store
 
+    field_store = getattr(field, "store", None)
+    if field_store and field_store.prefetch_related:
+        # When we have a prefetch_related in the field, skip the optimization as
+        # it will probably be filtering/annotating the queryset differently, and doing
+        # it here would result in an extra unused query
+        return store
+
     remote_field = model_field.remote_field
     remote_model = remote_field.model
     field_store = _get_model_hints(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1417,3 +1417,63 @@ def test_select_related_fallsback_to_prefetch_when_type_defines_get_queryset(
             {"pk": str(issue2.pk), "milestone": None},
         ],
     }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_prefetch_hint_with_same_name_field_no_extra_queries(
+    db,
+):
+    @strawberry_django.type(Issue)
+    class IssueType:
+        pk: strawberry.ID
+
+    @strawberry_django.type(Milestone)
+    class MilestoneType:
+        pk: strawberry.ID
+
+        @strawberry_django.field(
+            prefetch_related=[
+                lambda info: Prefetch(
+                    "issues",
+                    queryset=Issue.objects.filter(name__startswith="Foo"),
+                    to_attr="_my_issues",
+                ),
+            ],
+        )
+        def issues(self) -> List[IssueType]:
+            return self._my_issues  # type: ignore
+
+    @strawberry.type
+    class Query:
+        milestone: MilestoneType = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
+
+    milestone1 = MilestoneFactory.create()
+    milestone2 = MilestoneFactory.create()
+
+    issue1 = IssueFactory.create(name="Foo", milestone=milestone1)
+    IssueFactory.create(name="Bar", milestone=milestone1)
+    IssueFactory.create(name="Foo", milestone=milestone2)
+
+    query = """\
+      query TestQuery ($pk: ID!) {
+        milestone(pk: $pk) {
+          pk
+          issues {
+            pk
+          }
+        }
+      }
+    """
+
+    with assert_num_queries(2):
+        res = schema.execute_sync(query, {"pk": milestone1.pk})
+
+    assert res.errors is None
+    assert res.data == {
+        "milestone": {
+            "pk": str(milestone1.pk),
+            "issues": [{"pk": str(issue1.pk)}],
+        },
+    }

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, List, Optional, cast
+from typing import Any, List, cast
 
 import pytest
 import strawberry


### PR DESCRIPTION
Fix #559

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where prefetching with existing prefetch hints resulted in extra database queries. It includes a new test to verify the fix and updates the optimizer to skip unnecessary optimizations in such cases.

- **Bug Fixes**:
    - Fixed an issue where prefetching with existing prefetch hints caused extra database queries.
- **Enhancements**:
    - Updated the optimizer to skip optimization when a field has prefetch_related, preventing extra unused queries.
- **Tests**:
    - Added a test to ensure that prefetch hints with fields having the same name as the model do not cause extra database queries.

<!-- Generated by sourcery-ai[bot]: end summary -->