### PR TITLE
fix: Do not try to call an ordering object's `order` method if it is not a decorated method

### DIFF
--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -108,8 +108,10 @@ def process_order(
     sequence = sequence or {}
     args = []
 
-    if not skip_object_order_method and (order_method := getattr(order, "order", None)):
-        assert isinstance(order_method, FilterOrderFieldResolver)
+    if not skip_object_order_method and isinstance(
+        order_method := getattr(order, "order", None),
+        FilterOrderFieldResolver,
+    ):
         return order_method(
             order, info, queryset=queryset, prefix=prefix, sequence=sequence
         )


### PR DESCRIPTION
Fix #581

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a bug where the `order` method of an ordering object was incorrectly called even if it was not decorated. It also adds tests to verify that the `order` method is not called when it is not decorated and that an order field is not mistakenly called as a method.

- **Bug Fixes**:
    - Fixed an issue where the `order` method of an ordering object was called even if it was not a decorated method.
- **Tests**:
    - Added tests to ensure the `order` method is not called when it is not decorated.
    - Added tests to ensure that an order field is not called as a method.

<!-- Generated by sourcery-ai[bot]: end summary -->