### PR TITLE
fix: Avoid pagination failures when filtering connection by last without before/after

### DIFF
--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -1,3 +1,4 @@
+import sys
 from typing import TYPE_CHECKING, List, Optional, TypeVar, Union
 
 import strawberry
@@ -103,9 +104,13 @@ def apply_window_pagination(
             partition_by=related_field_id,
         ),
     )
+
     if offset:
         queryset = queryset.filter(_strawberry_row_number__gt=offset)
-    if limit >= 0:
+
+    # Limit == -1 means no limit. sys.maxsize is set by relay when paginating
+    # from the end to as a way to mimic a "not limit" as well
+    if limit >= 0 and limit != sys.maxsize:
         queryset = queryset.filter(_strawberry_row_number__lte=offset + limit)
 
     return queryset

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,6 +1,7 @@
 import io
 import textwrap
 from typing import List, Optional, cast
+from unittest import mock
 
 import pytest
 import strawberry
@@ -312,4 +313,4 @@ def test_field_name():
         }
       }
     """)
-    assert result.data == {"fruit": {"colorId": 1, "name": "Banana"}}
+    assert result.data == {"fruit": {"colorId": mock.ANY, "name": "Banana"}}


### PR DESCRIPTION
Fix #576

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses an issue with pagination failures when filtering connections by 'last' without 'before' or 'after' parameters. It includes new test cases to validate the correct behavior of window pagination under various conditions.

- **Bug Fixes**:
    - Fixed pagination failures when filtering connections by 'last' without 'before' or 'after' parameters.
- **Tests**:
    - Added test cases for window pagination to ensure correct behavior with and without limits.

<!-- Generated by sourcery-ai[bot]: end summary -->