### PR TITLE
fix: Only set False to clear FileFields when updating an instance

### DIFF
--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -248,10 +248,11 @@ def prepare_create_update(
             # Dont use these, fallback to model defaults.
             direct_field_value = False
         elif isinstance(field, models.FileField):
-            if value is None:
+            if value is None and instance.pk is not None:
                 # We want to reset the file field value when None was passed in the
                 # input, but `FileField.save_form_data` ignores None values. In that
-                # case we manually pass False which clears the file.
+                # case we manually pass False which clears the file
+                # (but only if the instance is already saved and we are updating it)
                 value = False  # noqa: PLW2901
         elif isinstance(field, (ManyToManyField, ForeignObjectRel)):
             # m2m will be processed later

--- a/tests/mutations/test_mutations.py
+++ b/tests/mutations/test_mutations.py
@@ -54,6 +54,30 @@ def test_create_with_optional_file(mutation):
     }
 
 
+def test_create_with_optional_file_when_not_setting_it(mutation):
+    result = mutation(
+        """\
+        CreateFruit($picture: Upload) {
+          createFruit(data: { name: "strawberry", picture: $picture }) {
+            id
+            name
+            picture {
+              name
+            }
+          }
+        }
+        """,
+        variable_values={"picture": None},
+    )
+
+    assert not result.errors
+    assert result.data["createFruit"] == {
+        "id": "1",
+        "name": "strawberry",
+        "picture": None,
+    }
+
+
 def test_update_with_optional_file_when_unsetting_it(mutation):
     fname = "test_update_with_optional_file.png"
     upload = prep_image(fname)


### PR DESCRIPTION
Fix #599

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a bug where FileField values were being incorrectly cleared during instance creation. It ensures that FileField values are only set to False to clear them when updating an existing instance. Additionally, a new test has been added to verify the correct handling of optional FileField values during creation.

- **Bug Fixes**:
    - Ensure FileField values are only set to False to clear them when updating an existing instance, preventing unintended clearing during creation.
- **Tests**:
    - Add a test to verify that optional FileField values are handled correctly when not set during creation.

<!-- Generated by sourcery-ai[bot]: end summary -->