### PR TITLE
Revert "Fix typo"

### DIFF
--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -4,7 +4,7 @@ title: Authentication
 
 # Authentication
 
-> [!WARNING]
+> ![WARNING]
 > This solution is enough for web browsers, but will not work for clients that
 > doesn't have a way to store cookies in it (e.g. mobile apps). For those it is
 > recommended to use token authentication methods. JWT can be used with

--- a/docs/guide/export-schema.md
+++ b/docs/guide/export-schema.md
@@ -4,7 +4,7 @@ title: Export Schema
 
 # Export Schema
 
-> [!INFO]
+> ![INFO]
 > The `export_schema` management command provided here is specifically designed for use with `strawberry_django`. The [default Strawberry export command](https://strawberry.rocks/docs/guides/schema-export) won't work with `strawberry_django` schemas because `strawberry_django` extends the base functionality of Strawberry to integrate with Django models and queries. This command ensures proper schema export functionality.
 
 The `export_schema` management command allows you to export a GraphQL schema defined using the `strawberry_django` library. This command converts the schema definition to GraphQL schema definition language (SDL), which can then be saved to a file or printed to the console.

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -4,7 +4,7 @@ title: Defining Fields
 
 # Defining Fields
 
-> [!TIP]
+> ![TIP]
 > It is highly recommended to enable the [Query Optimizer Extension](optimizer.md)
 > for improved performance and avoid some common pitfalls (e.g. the `n+1` issue)
 
@@ -27,7 +27,7 @@ class Fruit2:
     name: str
 ```
 
-> [!TIP]
+> ![TIP]
 > For choices using
 > [Django's TextChoices/IntegerChoices](https://docs.djangoproject.com/en/4.2/ref/models/fields/#enumeration-types)
 > it is recommented using the [django-choices-field](/integrations/choices-field) integration
@@ -122,7 +122,7 @@ field_type_map.update({
 
 ## Including / excluding Django model fields by name
 
-> [!WARNING]
+> ![WARNING]
 > These new keywords should be used with caution, as they may inadvertently lead to exposure of unwanted data. Especially with `fields="__all__"` or `exclude`, sensitive model attributes may be included and made available in the schema without your awareness.
 
 `strawberry_django.type` includes two optional keyword fields to help you populate fields from the Django model, `fields` and `exclude`.

--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -21,7 +21,7 @@ class Fruit:
     ...
 ```
 
-> [!TIP]
+> ![TIP]
 > In most cases filter fields should have `Optional` annotations and default value `strawberry.UNSET` like so:
 > `foo: Optional[SomeType] = strawberry.UNSET`
 > Above `auto` annotation is wrapped in `Optional` automatically.
@@ -40,7 +40,7 @@ input FruitFilter {
 }
 ```
 
-> [!TIP]
+> ![TIP]
 > If you are using the [relay integration](relay.md) and working with types inheriting
 > from `relay.Node` and `GlobalID` for identifying objects, you might want to set
 > `MAP_AUTO_ID_AS_GLOBAL_ID=True` in your [strawberry django settings](../settings)
@@ -204,11 +204,11 @@ class FruitFilter:
         )
 ```
 
-> [!WARNING]
+> ![WARNING]
 > It is discouraged to use `queryset.filter()` directly. When using more
 > complex filtering via `NOT`, `OR` & `AND` this might lead to undesired behaviour.
 
-> [!TIP]
+> ![TIP]
 >
 > #### process_filters
 >
@@ -342,7 +342,7 @@ class FruitFilter:
         )
 ```
 
-> [!TIP]
+> ![TIP]
 > As seen above `strawberry_django.process_filters` function is exposed and can be
 > reused in custom methods.
 > For filter method `filter` `skip_object_order_method` was used to avoid endless recursion.
@@ -421,7 +421,7 @@ There is 7 already defined Generic Lookup `strawberry.input` classes importable 
 
 The previous version of filters can be enabled via [**USE_DEPRECATED_FILTERS**](settings.md#strawberry_django)
 
-> [!WARNING]
+> ![WARNING]
 > If **USE_DEPRECATED_FILTERS** is not set to `True` legacy custom filtering
 > methods will be _not_ be called.
 

--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -85,7 +85,7 @@ mutation {
 }
 ```
 
-> [!TIP]
+> ![TIP]
 > If all or most of your mutations use this behaviour, you can change the
 > default behaviour for `handle_django_errors` by setting
 > `MUTATIONS_DEFAULT_HANDLE_ERRORS=True` in your [strawberry django settings](../settings)
@@ -167,7 +167,7 @@ class Mutation:
 
 ## Filtering
 
-> [!CAUTION]
+> ![CAUTION]
 > This is totally discouraged as it allows for any issue with the filters
 > to be able to alter your whole model collection.
 

--- a/docs/guide/optimizer.md
+++ b/docs/guide/optimizer.md
@@ -168,7 +168,7 @@ Song.objects.all().only(
 )
 ```
 
-> [!NOTE]
+> ![NOTE]
 > Even though `album__release_date` field was not selected here, it got selected
 > in the prefetch query later. Since Django caches known objects, we have to select it here or
 > else it would trigger extra queries latter.

--- a/docs/guide/ordering.md
+++ b/docs/guide/ordering.md
@@ -15,7 +15,7 @@ class FruitOrder:
     color: ColorOrder | None
 ```
 
-> [!TIP]
+> ![TIP]
 > In most cases order fields should have `Optional` annotations and default value `strawberry.UNSET`.
 > Above `auto` annotation is wrapped in `Optional` automatically.
 > `UNSET` is automatically used for fields without `field` or with `strawberry_django.order_field`.
@@ -73,11 +73,11 @@ class FruitOrder:
         return queryset, [ordering]
 ```
 
-> [!WARNING]
+> ![WARNING]
 > Do not use `queryset.order_by()` directly. Due to `order_by` not being chainable
 > operation, changes applied this way would be overriden later.
 
-> [!TIP] > `strawberry_django.Ordering` has convenient method `resolve` that can be used to
+> ![TIP] > `strawberry_django.Ordering` has convenient method `resolve` that can be used to
 > convert field's name to appropriate `F` object with correctly applied `asc()`, `desc()` method
 > with `nulls_first` and `nulls_last` arguments.
 
@@ -208,7 +208,7 @@ class FruitOrder:
 
 ```
 
-> [!TIP]
+> ![TIP]
 > As seen above `strawberry_django.process_order` function is exposed and can be
 > reused in custom methods.
 > For order method `order` `skip_object_order_method` was used to avoid endless recursion.

--- a/docs/guide/permissions.md
+++ b/docs/guide/permissions.md
@@ -78,7 +78,7 @@ Available options are:
   will filter the return value, removing objects that fails the check (check below for more
   information regarding other possibilities).
 
-> [!NOTE]
+> ![NOTE]
 > The `HasSourcePerm` and `HasRetvalPerm` require having an
 > [authentication backend](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/)
 > which supports resolving object permissions. This lib works out of the box with

--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -23,7 +23,7 @@ class Query:
 schema = strawberry.Schema(query=Query)
 ```
 
-> [!TIP]
+> ![TIP]
 > You must name your query class "Query" or decorate it with `@strawberry.type(name="Query")` for the single query default primary filter to work
 
 For the single queries (like `Fruit` above), Strawberry comes with a default primary key search filter in the GraphiQL interface. The query `Fruits` gets all the objects in the Fruits by default. To query specific sets of objects a filter need to be added in the `types.py` file.

--- a/docs/guide/relay.md
+++ b/docs/guide/relay.md
@@ -55,7 +55,7 @@ Behind the scenes this extension is doing the following for you:
 You can also define your own `relay.NodeID` field and your resolve, in the same way as
 `some_model_conn_with_resolver` is doing. In those cases, they will not be overridden.
 
-> [!TIP]
+> ![TIP]
 > If you are only working with types inheriting from `relay.Node` and `GlobalID`
 > for identifying objects, you might want to set `MAP_AUTO_ID_AS_GLOBAL_ID=True`
 > in your [strawberry django settings](../settings) to make sure `auto` fields gets

--- a/docs/guide/types.md
+++ b/docs/guide/types.md
@@ -92,7 +92,7 @@ on [How to define Fields](fields.md) for that.
 
 ### Customizing the returned `QuerySet`
 
-> [!WARNING]
+> ![WARNING]
 > By doing this you are modifying all automatic `QuerySet` generation for any field
 > that returns this type. Ideally you will want to define your own [resolver](resolvers.md)
 > instead, which gives you more control over it.
@@ -131,7 +131,7 @@ class Berry:
         return queryset.filter(name__contains="berry")
 ```
 
-> [!NOTE]
+> ![NOTE]
 > Another way of limiting this is by using the [PermissionExtension](permissions.md)
 > provided by this lib.
 


### PR DESCRIPTION
This reverts commit f845a0c7e854fc3cb3f55945b487650e8a3ed562.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request reverts a previous commit that fixed a typo in multiple documentation files. The changes restore the original state of the documentation by replacing the corrected 'TIP', 'WARNING', 'CAUTION', 'INFO', and 'NOTE' annotations with their previous incorrect forms.

<!-- Generated by sourcery-ai[bot]: end summary -->