### PR TITLE
Fix calculation of `has_next_page` in `resolve_connection_from_cache`

### DIFF
--- a/strawberry_django/relay.py
+++ b/strawberry_django/relay.py
@@ -188,11 +188,15 @@ class ListConnectionWithTotalCount(relay.ListConnection[relay.NodeType]):
             for node in result
         ]
         has_previous_page = (
-            nodes[0]._strawberry_row_number > 1  # type: ignore
+            result[0]._strawberry_row_number > 1  # type: ignore
             if result
             else False
         )
-        has_next_page = result._strawberry_row_number < result if result else False
+        has_next_page = (
+            result[-1]._strawberry_row_number < result[-1]._strawberry_total_count  # type: ignore
+            if result
+            else False
+        )
 
         return cls(
             edges=edges,

--- a/tests/relay/test_nested_pagination.py
+++ b/tests/relay/test_nested_pagination.py
@@ -1,0 +1,62 @@
+import pytest
+from strawberry.relay import to_base64
+from strawberry.relay.types import PREFIX
+
+from strawberry_django.optimizer import DjangoOptimizerExtension
+from tests import utils
+from tests.projects.faker import IssueFactory, MilestoneFactory
+
+
+@pytest.mark.django_db(transaction=True)
+def test_nested_pagination(gql_client: utils.GraphQLTestClient):
+    # Nested pagination with the same arguments for the parent and child connections
+    query = """
+      query testNestedConnectionPagination($first: Int, $after: String) {
+        milestoneConn(first: $first, after: $after) {
+          edges {
+            node {
+              id
+              issuesWithFilters(first: $first, after: $after) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    # Create 4 milestones, each with 4 issues
+    nested_data = {
+        milestone: IssueFactory.create_batch(4, milestone=milestone)
+        for milestone in MilestoneFactory.create_batch(4)
+    }
+
+    # Run the nested pagination query
+    # We expect only 2 database queries if the optimizer is enabled, otherwise 3 (N+1)
+    with utils.assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 3):
+        result = gql_client.query(query, {"first": 2, "after": to_base64(PREFIX, 0)})
+
+    # We expect the 2nd and 3rd milestones each with their 2nd and 3rd issues
+    assert not result.errors
+    assert result.data == {
+        "milestoneConn": {
+            "edges": [
+                {
+                    "node": {
+                        "id": to_base64("MilestoneType", milestone.id),
+                        "issuesWithFilters": {
+                            "edges": [
+                                {"node": {"id": to_base64("IssueType", issue.id)}}
+                                for issue in issues[1:3]
+                            ]
+                        },
+                    }
+                }
+                for milestone, issues in list(nested_data.items())[1:3]
+            ]
+        }
+    }


### PR DESCRIPTION
## Description

The `strawberry_django.relay.ListConnectionWithTotalCount.resolve_connection_from_cache` method currently incorrectly attempts to determine `has_next_page` from the `QuerySet._result_cache`, as opposed to the cached records within it, resulting in an `AttributeError` being raised.

This PR ensures that `has_next_page` is determined via the _last_ record in the `QuerySet._result_cache` (if applicable), so that we don't get an `AttributeError`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Partially fixes #613 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the calculation of `has_next_page` in `resolve_connection_from_cache` to prevent an `AttributeError` by using the last record in the `QuerySet._result_cache`.

Bug Fixes:
- Fix the calculation of `has_next_page` in `resolve_connection_from_cache` to prevent an `AttributeError` by correctly determining it from the last record in the `QuerySet._result_cache`.

<!-- Generated by sourcery-ai[bot]: end summary -->