### PR TITLE
Change default Relay input m2m types from `ListInput[NodeInputPartial]` to `ListInput[NodeInput]`

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -404,9 +404,9 @@ relay_input_field_type_map: Dict[
     type,
 ] = {
     related.ForeignKey: NodeInput,
-    related.ManyToManyField: ListInput[NodeInputPartial],
+    related.ManyToManyField: ListInput[NodeInput],
     related.OneToOneField: NodeInput,
-    reverse_related.ManyToManyRel: ListInput[NodeInputPartial],
+    reverse_related.ManyToManyRel: ListInput[NodeInput],
     reverse_related.ManyToOneRel: ListInput[NodeInput],
     reverse_related.OneToOneRel: NodeInput,
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail here. -->

The default Relay input field type for a `ManyToManyField` or `ManyToManyRel` marked with `strawberry.auto` is `ListInput[NodeInputPartial]`.

This means the following is allowed in mutations:
```jsonc
// Set
{
  "data": {
    "my_related_field": {
      "set": [{"id": null}, {"id": null}, ...]
    }
  }
}

// Add
{
  "data": {
    "my_related_field": {
      "add": [{"id": null}, {"id": null}, ...]
    }
  }
}

// Remove
{
  "data": {
    "my_related_field": {
      "remove": [{"id": null}, {"id": null}, ...]
    }
  }
}
```

I can't think of a scenario where allowing `{"id": null}` would be the expected / desired behaviour (at least by default), and it causes some weird errors in the default CUD mutations. For `add` / `set` / `remove` it seems appropriate that the `"id"` Global ID field should be required by default.

This PR changes the default Relay input type for `ManyToManyField` and `ManyToManyRel` from `ListInput[NodeInputPartial]` to `ListInput[NodeInput]` so that the above is no longer possible.

For reference, this seems to match [the non-Relay behaviour](https://github.com/strawberry-graphql/strawberry-django/blob/c6e8b6547e8ac8adea1dda04921daf89d1fed767/strawberry_django/fields/types.py#L96-L100) of `ManyToManyInput`, which doesn't allow `null` for its IDs.

**The unit tests all still pass with this change, but if this actually *isn't* a bug then I'm happy to close this PR.**

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the default input type for ManyToManyField and ManyToManyRel in Relay to require non-null IDs, aligning with non-Relay behavior and preventing unexpected errors in CUD mutations.

Bug Fixes:
- Change the default Relay input type for ManyToManyField and ManyToManyRel from ListInput[NodeInputPartial] to ListInput[NodeInput] to prevent allowing null IDs in mutations.

<!-- Generated by sourcery-ai[bot]: end summary -->