### PR TITLE
refactor: Remove guardian ObjectPermissionChecker monkey patch

### DIFF
--- a/strawberry_django/integrations/guardian.py
+++ b/strawberry_django/integrations/guardian.py
@@ -1,21 +1,15 @@
 import contextlib
 import dataclasses
-import weakref
-from typing import Optional, Type, Union, cast
+from typing import Type, Union, cast
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.db import models
-from guardian import backends as _guardian_backends
 from guardian.conf import settings as guardian_settings
-from guardian.core import ObjectPermissionChecker as _ObjectPermissionChecker
 from guardian.models.models import GroupObjectPermissionBase, UserObjectPermissionBase
 from guardian.utils import get_anonymous_user as _get_anonymous_user
 from guardian.utils import get_group_obj_perms_model, get_user_obj_perms_model
 
 from strawberry_django.utils.typing import UserType
-
-_cache = weakref.WeakKeyDictionary()
 
 
 @dataclasses.dataclass
@@ -39,18 +33,3 @@ def get_user_or_anonymous(user: UserType) -> UserType:
         with contextlib.suppress(get_user_model().DoesNotExist):
             return cast(UserType, _get_anonymous_user())
     return user
-
-
-class ObjectPermissionChecker(_ObjectPermissionChecker):
-    def __new__(cls, user_or_group: Optional[Union[UserType, Group]] = None):
-        if user_or_group is not None and user_or_group in _cache:
-            return _cache[user_or_group]
-
-        obj = _ObjectPermissionChecker(user_or_group=user_or_group)
-        _cache[user_or_group] = obj
-
-        return obj
-
-
-# Use our implementation that reuses the checker for the same user/group
-_guardian_backends.ObjectPermissionChecker = ObjectPermissionChecker


### PR DESCRIPTION
This is an old monkey patch that was introduced back when this code used to live in `strawberry-django-plus`, with the intention of avoiding too many queries to the database when fetching permissions.

This ended up causing an issue, as checking for a permission would cache the result, and later when trying to modify the permissions and checking those again would return the cached result instead.

This seems like to not be required anymore as well, based on the fact that we have a lot of unit tests that test the permissioning stuff with guardian, while also ensuring that the number of db requests are known, and none presented any issues.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the code to remove the custom monkey patch for ObjectPermissionChecker, which was causing caching issues with permission checks. This change relies on existing unit tests to ensure that permission handling remains efficient and correct without the patch.

Enhancements:
- Remove the custom monkey patch for ObjectPermissionChecker to prevent caching issues with permission checks.

<!-- Generated by sourcery-ai[bot]: end summary -->