### PR TITLE
Changed the recommended library for JWT Authentication in Django to strawberry-django-auth

### DIFF
--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -8,7 +8,7 @@ title: Authentication
 > This solution is enough for web browsers, but will not work for clients that
 > doesn't have a way to store cookies in it (e.g. mobile apps). For those it is
 > recommended to use token authentication methods. JWT can be used with
-> [strawberry-django-jwt](https://github.com/KundaPanda/strawberry-django-jwt)
+> [strawberry-django-auth](https://github.com/nrbnlulu/strawberry-django-auth)
 > lib.
 
 `strawberry_django` provides mutations to get authentication going right away.


### PR DESCRIPTION
Changed the JWT library recommendation from `strawberry-django-jwt` to [strawberry-django-auth](https://github.com/nrbnlulu/strawberry-django-auth) in the documentation as the old library is unmaintained and recommends using the latter library by itself.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Change the recommended JWT authentication library in the Django documentation to 'strawberry-django-auth' as the previous library is no longer maintained.

Documentation:
- Update the recommended library for JWT authentication in Django documentation from 'strawberry-django-jwt' to 'strawberry-django-auth' due to the former being unmaintained.

<!-- Generated by sourcery-ai[bot]: end summary -->