### PR TITLE
feat: New Paginated generic to be used as a wrapped for paginated results

### DIFF
--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -12,20 +12,190 @@ An interface for limit/offset pagination can be use for basic pagination needs:
 @strawberry_django.type(models.Fruit, pagination=True)
 class Fruit:
     name: auto
+
+
+@strawberry.type
+class Query:
+    fruits: list[Fruit] = strawberry_django.field()
 ```
+
+Would produce the following schema:
+
+```graphql title="schema.graphql"
+type Fruit {
+  name: String!
+}
+
+type Query {
+  fruits(pagination: PaginationInput): [Fruit!]!
+}
+```
+
+And can be queried like:
 
 ```graphql title="schema.graphql"
 query {
   fruits(pagination: { offset: 0, limit: 2 }) {
     name
-    color
   }
 }
 ```
 
-There is not default limit defined. All elements are returned if no pagination limit is defined.
+The `pagination` argument can be given to the type, which will enforce the pagination
+argument every time the field is annotated as a list, but you can also give it directly
+to the field for more control, like:
 
-## Relay pagination
+```python title="types.py"
+@strawberry_django.type(models.Fruit)
+class Fruit:
+    name: auto
 
-For more complex scenarios, a cursor pagination would be better. For this,
-use the [relay integration](./relay.md) to define those.
+
+@strawberry.type
+class Query:
+    fruits: list[Fruit] = strawberry_django.field(pagination=True)
+```
+
+Which will produce the exact same schema.
+
+> [!NOTE]
+> There is no default limit defined. All elements are returned if no pagination limit is defined.
+
+## Paginated Generic
+
+For more complex pagination needs, you can use the `Paginated` generic, which alongside
+the `pagination` argument, will wrap the results in an object that contains the results
+and the pagination information, together with the `totalCount` of elements excluding pagination.
+
+```python title="types.py"
+from strawberry_django.pagination import Paginated
+
+
+@strawberry_django.type(models.Fruit)
+class Fruit:
+    name: auto
+
+
+@strawberry.type
+class Query:
+    fruits: Paginated[Fruit] = strawberry_django.field()
+```
+
+Would produce the following schema:
+
+```graphql title="schema.graphql"
+type Fruit {
+  name: String!
+}
+
+type PaginatedInfo {
+  limit: Int!
+  offset: Int!
+}
+
+type FruitPaginated {
+  pageInfo: PaginatedInfo!
+  totalCount: Int!
+  results: [Fruit]!
+}
+
+type Query {
+  fruits(pagination: PaginationInput): [FruitPaginated!]!
+}
+```
+
+Which can be queried like:
+
+```graphql title="schema.graphql"
+query {
+  fruits(pagination: { offset: 0, limit: 2 }) {
+    totalCount
+    pageInfo {
+      limit
+      offset
+    }
+    results {
+      name
+    }
+  }
+}
+```
+
+### Customizing the pagination
+
+Like other generics, `Paginated` can be customized to modify its behavior or to
+add extra functionality in it. For example, suppose we want to add the average
+price of the fruits in the pagination:
+
+```python title="types.py"
+from strawberry_django.pagination import Paginated
+
+
+@strawberry_django.type(models.Fruit)
+class Fruit:
+    name: auto
+    price: auto
+
+
+@strawberry.type
+class FruitPaginated(Paginated[Fruit]):
+    @strawberry_django.field
+    def average_price(self) -> Decimal:
+        if self.queryset is None:
+            return Decimal(0)
+
+        return self.queryset.aggregate(Avg("price"))["price__avg"]
+
+    @strawberry_django.field
+    def paginated_average_price(self) -> Decimal:
+        paginated_queryset = self.get_paginated_queryset()
+        if paginated_queryset is None:
+            return Decimal(0)
+
+        return paginated_queryset.aggregate(Avg("price"))["price__avg"]
+
+
+@strawberry.type
+class Query:
+    fruits: FruitPaginated = strawberry_django.field()
+```
+
+Would produce the following schema:
+
+```graphql title="schema.graphql"
+type Fruit {
+  name: String!
+}
+
+type PaginatedInfo {
+  limit: Int!
+  offset: Int!
+}
+
+type FruitPaginated {
+  pageInfo: PaginatedInfo!
+  totalCount: Int!
+  results: [Fruit]!
+  averagePrice: Decimal!
+  paginatedAveragePrice: Decimal!
+}
+
+type Query {
+  fruits(pagination: PaginationInput): [FruitPaginated!]!
+}
+```
+
+The following attributes/methods can be accessed in the `Paginated` class:
+
+- `queryset`: The queryset original queryset with any filters/ordering applied,
+  but not paginated yet
+- `pagination`: The `OffsetPaginationInput` object, with the `offset` and `limit` for pagination
+- `get_total_count()`: Returns the total count of elements in the queryset without pagination
+- `get_paginated_queryset()`: Returns the queryset with pagination applied
+
+## Cursor pagination (aka Relay style pagination)
+
+Another option for pagination is to use a
+[relay style cursor pagination](https://graphql.org/learn/pagination). For this,
+you can leverage the [relay integration](./relay.md) provided by strawberry
+to create a relay connection.

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -63,8 +63,32 @@ class Query:
 
 Which will produce the exact same schema.
 
-> [!NOTE]
-> There is no default limit defined. All elements are returned if no pagination limit is defined.
+### Default limit for pagination
+
+The default limit for pagination is set to `100`. This can be changed in the
+[strawberry django settings](./settings.md) to increase or decrease that number,
+or even set to `None` to set it to unlimited.
+
+To configure it on a per field basis, you can define your own `OffsetPaginationInput`
+subclass and modify its default value, like:
+
+```python
+@strawberry.input
+def MyOffsetPaginationInput(OffsetPaginationInput):
+    limit: int = 250
+
+
+# Pass it to the pagination argument when defining the type
+@strawberry_django.type(models.Fruit, pagination=MyOffsetPaginationInput)
+class Fruit:
+    ...
+
+
+@strawberry.type
+class Query:
+    # Or pass it to the pagination argument when defining the field
+    fruits: list[Fruit] = strawberry_django.field(pagination=MyOffsetPaginationInput)
+```
 
 ## Paginated Generic
 
@@ -130,6 +154,10 @@ query {
   }
 }
 ```
+
+> [!NOTE]
+> Paginated follow the same rules for the default pagination limit, and can be configured
+> in the same way as explained above.
 
 ### Customizing the pagination
 

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -28,7 +28,7 @@ type Fruit {
 
 input OffsetPaginationInput {
   offset: Int! = 0
-  limit: Int! = -1
+  limit: Int = null
 }
 
 type Query {
@@ -107,7 +107,7 @@ class Fruit:
 
 @strawberry.type
 class Query:
-    fruits: OffsetPaginated[Fruit] = strawberry_django.field()
+    fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated()
 ```
 
 Would produce the following schema:
@@ -118,7 +118,7 @@ type Fruit {
 }
 
 type PaginationInfo {
-  limit: Int!
+  limit: Int = null
   offset: Int!
 }
 
@@ -130,7 +130,7 @@ type FruitOffsetPaginated {
 
 input OffsetPaginationInput {
   offset: Int! = 0
-  limit: Int! = -1
+  limit: Int = null
 }
 
 type Query {
@@ -158,6 +158,77 @@ query {
 > [!NOTE]
 > OffsetPaginated follow the same rules for the default pagination limit, and can be configured
 > in the same way as explained above.
+
+### Customizing queryset resolver
+
+It is possible to define a custom resolver for the queryset to either provide a custom
+queryset for it, or even to receive extra arguments alongside the pagination arguments.
+
+Suppose we want to pre-filter a queryset of fruits for only available ones,
+while also adding [ordering](./ordering.md) to it. This can be achieved like:
+
+```python title="types.py"
+
+@strawberry_django.type(models.Fruit)
+class Fruit:
+    name: auto
+    price: auto
+
+
+@strawberry_django.order(models.Fruit)
+class FruitOrder:
+    name: auto
+    price: auto
+
+
+@strawberry.type
+class Query:
+    @straberry.offset_paginated(OffsetPaginated[Fruit], order=order)
+    def fruits(self, only_available: bool = True) -> QuerySet[Fruit]:
+        queryset = models.Fruit.objects.all()
+        if only_available:
+            queryset = queryset.filter(available=True)
+
+        return queryset
+```
+
+This would produce the following schema:
+
+```graphql title="schema.graphql"
+type Fruit {
+  name: String!
+  price: Decimal!
+}
+
+type FruitOrder {
+  name: Ordering
+  price: Ordering
+}
+
+type PaginationInfo {
+  limit: Int!
+  offset: Int!
+}
+
+type FruitOffsetPaginated {
+  pageInfo: PaginationInfo!
+  totalCount: Int!
+  results: [Fruit]!
+}
+
+input OffsetPaginationInput {
+  offset: Int! = 0
+  limit: Int = null
+}
+
+type Query {
+  fruits(
+    onlyAvailable: Boolean! = true
+    pagination: OffsetPaginationInput
+    order: FruitOrder
+  ): [FruitOffsetPaginated!]!
+}
+```
 
 ### Customizing the pagination
 
@@ -195,7 +266,7 @@ class FruitOffsetPaginated(OffsetPaginated[Fruit]):
 
 @strawberry.type
 class Query:
-    fruits: FruitOffsetPaginated = strawberry_django.field()
+    fruits: FruitOffsetPaginated = strawberry_django.offset_paginated()
 ```
 
 Would produce the following schema:
@@ -206,7 +277,7 @@ type Fruit {
 }
 
 type PaginationInfo {
-  limit: Int!
+  limit: Int = null
   offset: Int!
 }
 
@@ -220,7 +291,7 @@ type FruitOffsetPaginated {
 
 input OffsetPaginationInput {
   offset: Int! = 0
-  limit: Int! = -1
+  limit: Int = null
 }
 
 type Query {

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -90,14 +90,14 @@ class Query:
     fruits: list[Fruit] = strawberry_django.field(pagination=MyOffsetPaginationInput)
 ```
 
-## Paginated Generic
+## OffsetPaginated Generic
 
-For more complex pagination needs, you can use the `Paginated` generic, which alongside
+For more complex pagination needs, you can use the `OffsetPaginated` generic, which alongside
 the `pagination` argument, will wrap the results in an object that contains the results
 and the pagination information, together with the `totalCount` of elements excluding pagination.
 
 ```python title="types.py"
-from strawberry_django.pagination import Paginated
+from strawberry_django.pagination import OffsetPaginated
 
 
 @strawberry_django.type(models.Fruit)
@@ -107,7 +107,7 @@ class Fruit:
 
 @strawberry.type
 class Query:
-    fruits: Paginated[Fruit] = strawberry_django.field()
+    fruits: OffsetPaginated[Fruit] = strawberry_django.field()
 ```
 
 Would produce the following schema:
@@ -117,13 +117,13 @@ type Fruit {
   name: String!
 }
 
-type PaginatedInfo {
+type PaginationInfo {
   limit: Int!
   offset: Int!
 }
 
-type FruitPaginated {
-  pageInfo: PaginatedInfo!
+type FruitOffsetPaginated {
+  pageInfo: PaginationInfo!
   totalCount: Int!
   results: [Fruit]!
 }
@@ -134,7 +134,7 @@ input OffsetPaginationInput {
 }
 
 type Query {
-  fruits(pagination: OffsetPaginationInput): [FruitPaginated!]!
+  fruits(pagination: OffsetPaginationInput): [FruitOffsetPaginated!]!
 }
 ```
 
@@ -156,17 +156,17 @@ query {
 ```
 
 > [!NOTE]
-> Paginated follow the same rules for the default pagination limit, and can be configured
+> OffsetPaginated follow the same rules for the default pagination limit, and can be configured
 > in the same way as explained above.
 
 ### Customizing the pagination
 
-Like other generics, `Paginated` can be customized to modify its behavior or to
+Like other generics, `OffsetPaginated` can be customized to modify its behavior or to
 add extra functionality in it. For example, suppose we want to add the average
 price of the fruits in the pagination:
 
 ```python title="types.py"
-from strawberry_django.pagination import Paginated
+from strawberry_django.pagination import OffsetPaginated
 
 
 @strawberry_django.type(models.Fruit)
@@ -176,7 +176,7 @@ class Fruit:
 
 
 @strawberry.type
-class FruitPaginated(Paginated[Fruit]):
+class FruitOffsetPaginated(OffsetPaginated[Fruit]):
     @strawberry_django.field
     def average_price(self) -> Decimal:
         if self.queryset is None:
@@ -195,7 +195,7 @@ class FruitPaginated(Paginated[Fruit]):
 
 @strawberry.type
 class Query:
-    fruits: FruitPaginated = strawberry_django.field()
+    fruits: FruitOffsetPaginated = strawberry_django.field()
 ```
 
 Would produce the following schema:
@@ -205,13 +205,13 @@ type Fruit {
   name: String!
 }
 
-type PaginatedInfo {
+type PaginationInfo {
   limit: Int!
   offset: Int!
 }
 
-type FruitPaginated {
-  pageInfo: PaginatedInfo!
+type FruitOffsetPaginated {
+  pageInfo: PaginationInfo!
   totalCount: Int!
   results: [Fruit]!
   averagePrice: Decimal!
@@ -224,11 +224,11 @@ input OffsetPaginationInput {
 }
 
 type Query {
-  fruits(pagination: OffsetPaginationInput): [FruitPaginated!]!
+  fruits(pagination: OffsetPaginationInput): [FruitOffsetPaginated!]!
 }
 ```
 
-The following attributes/methods can be accessed in the `Paginated` class:
+The following attributes/methods can be accessed in the `OffsetPaginated` class:
 
 - `queryset`: The queryset original queryset with any filters/ordering applied,
   but not paginated yet

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -165,7 +165,7 @@ It is possible to define a custom resolver for the queryset to either provide a 
 queryset for it, or even to receive extra arguments alongside the pagination arguments.
 
 Suppose we want to pre-filter a queryset of fruits for only available ones,
-while also adding [ordering](./ordering.md) to it. This can be achieved like:
+while also adding [ordering](./ordering.md) to it. This can be achieved with:
 
 ```python title="types.py"
 
@@ -183,7 +183,7 @@ class FruitOrder:
 
 @strawberry.type
 class Query:
-    @straberry.offset_paginated(OffsetPaginated[Fruit], order=order)
+    @strawberry_django.offset_paginated(OffsetPaginated[Fruit], order=order)
     def fruits(self, only_available: bool = True) -> QuerySet[Fruit]:
         queryset = models.Fruit.objects.all()
         if only_available:

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -235,6 +235,8 @@ The following attributes/methods can be accessed in the `OffsetPaginated` class:
 - `pagination`: The `OffsetPaginationInput` object, with the `offset` and `limit` for pagination
 - `get_total_count()`: Returns the total count of elements in the queryset without pagination
 - `get_paginated_queryset()`: Returns the queryset with pagination applied
+- `resolve_paginated(queryset, *, info, pagiantion, **kwargs)`: The classmethod that
+  strawberry-django calls to create an instance of the `OffsetPaginated` class/subclass.
 
 ## Cursor pagination (aka Relay style pagination)
 

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -26,8 +26,13 @@ type Fruit {
   name: String!
 }
 
+input OffsetPaginationInput {
+  offset: Int! = 0
+  limit: Int! = -1
+}
+
 type Query {
-  fruits(pagination: PaginationInput): [Fruit!]!
+  fruits(pagination: OffsetPaginationInput): [Fruit!]!
 }
 ```
 
@@ -99,8 +104,13 @@ type FruitPaginated {
   results: [Fruit]!
 }
 
+input OffsetPaginationInput {
+  offset: Int! = 0
+  limit: Int! = -1
+}
+
 type Query {
-  fruits(pagination: PaginationInput): [FruitPaginated!]!
+  fruits(pagination: OffsetPaginationInput): [FruitPaginated!]!
 }
 ```
 
@@ -180,8 +190,13 @@ type FruitPaginated {
   paginatedAveragePrice: Decimal!
 }
 
+input OffsetPaginationInput {
+  offset: Int! = 0
+  limit: Int! = -1
+}
+
 type Query {
-  fruits(pagination: PaginationInput): [FruitPaginated!]!
+  fruits(pagination: OffsetPaginationInput): [FruitPaginated!]!
 }
 ```
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -62,7 +62,11 @@ A dictionary with the following optional keys:
 
       If True, [legacy filters](filters.md#legacy-filtering) are enabled. This is usefull for migrating from previous version.
 
-These features can be enabled by adding this code to your `settings.py` file.
+- **`PAGINATION_DEFAULT_LIMIT`** (default: `100`)
+
+      Defualt limit for [pagination](pagination.md) when one is not provided by the client. Can be set to `None` to set it to unlimited.
+
+These features can be enabled by adding this code to your `settings.py` file, like:
 
 ```python title="settings.py"
 STRAWBERRY_DJANGO = {
@@ -73,5 +77,6 @@ STRAWBERRY_DJANGO = {
     "GENERATE_ENUMS_FROM_CHOICES": False,
     "MAP_AUTO_ID_AS_GLOBAL_ID": True,
     "DEFAULT_PK_FIELD_NAME": "id",
+    "PAGINATION_DEFAULT_LIMIT": 250,
 }
 ```

--- a/strawberry_django/__init__.py
+++ b/strawberry_django/__init__.py
@@ -1,5 +1,5 @@
 from . import auth, filters, mutations, ordering, pagination, relay
-from .fields.field import connection, field, node
+from .fields.field import connection, field, node, offset_paginated
 from .fields.filter_order import filter_field, order_field
 from .fields.filter_types import (
     BaseFilterLookup,
@@ -60,6 +60,7 @@ __all__ = [
     "mutation",
     "mutations",
     "node",
+    "offset_paginated",
     "order",
     "order_field",
     "ordering",

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -85,7 +85,7 @@ class StrawberryDjangoFieldBase(StrawberryField):
 
     @functools.cached_property
     def django_type(self) -> type[WithStrawberryDjangoObjectDefinition] | None:
-        from strawberry_django.pagination import Paginated
+        from strawberry_django.pagination import OffsetPaginated
 
         origin = self.type
 
@@ -95,7 +95,7 @@ class StrawberryDjangoFieldBase(StrawberryField):
         object_definition = get_object_definition(origin)
 
         if object_definition and issubclass(
-            object_definition.origin, (relay.Connection, Paginated)
+            object_definition.origin, (relay.Connection, OffsetPaginated)
         ):
             origin_specialized_type_var_map = (
                 get_specialized_type_var_map(cast(type, origin)) or {}
@@ -154,13 +154,13 @@ class StrawberryDjangoFieldBase(StrawberryField):
 
     @functools.cached_property
     def is_paginated(self) -> bool:
-        from strawberry_django.pagination import Paginated
+        from strawberry_django.pagination import OffsetPaginated
 
         type_ = self.type
         if isinstance(type_, StrawberryOptional):
             type_ = type_.of_type
 
-        return isinstance(type_, type) and issubclass(type_, Paginated)
+        return isinstance(type_, type) and issubclass(type_, OffsetPaginated)
 
     @functools.cached_property
     def is_connection(self) -> bool:

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -85,6 +85,8 @@ class StrawberryDjangoFieldBase(StrawberryField):
 
     @functools.cached_property
     def django_type(self) -> type[WithStrawberryDjangoObjectDefinition] | None:
+        from strawberry_django.pagination import Paginated
+
         origin = self.type
 
         if isinstance(origin, LazyType):
@@ -92,7 +94,9 @@ class StrawberryDjangoFieldBase(StrawberryField):
 
         object_definition = get_object_definition(origin)
 
-        if object_definition and issubclass(object_definition.origin, relay.Connection):
+        if object_definition and issubclass(
+            object_definition.origin, (relay.Connection, Paginated)
+        ):
             origin_specialized_type_var_map = (
                 get_specialized_type_var_map(cast(type, origin)) or {}
             )
@@ -147,6 +151,16 @@ class StrawberryDjangoFieldBase(StrawberryField):
             type_ = type_.of_type
 
         return isinstance(type_, StrawberryList)
+
+    @functools.cached_property
+    def is_paginated(self) -> bool:
+        from strawberry_django.pagination import Paginated
+
+        type_ = self.type
+        if isinstance(type_, StrawberryOptional):
+            type_ = type_.of_type
+
+        return isinstance(type_, type) and issubclass(type_, Paginated)
 
     @functools.cached_property
     def is_connection(self) -> bool:

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -229,7 +229,7 @@ class StrawberryDjangoField(
                         kwargs["info"] = info
 
                     @sync_to_async
-                    def resolve():
+                    def resolve(resolved=resolved):
                         inner_resolved = self.get_queryset_hook(**kwargs)(resolved)
                         return self.get_wrapped_result(inner_resolved, **kwargs)
 

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -246,8 +246,8 @@ class StrawberryDjangoField(
                 kwargs["info"] = info
 
             result = django_resolver(
-                partial(self.get_wrapped_result, **kwargs),
-                qs_hook=self.get_queryset_hook(**kwargs),
+                self.get_queryset_hook(**kwargs),
+                qs_hook=partial(self.get_wrapped_result, **kwargs),
             )(result)
 
         return result

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -309,6 +309,7 @@ class StrawberryDjangoFieldFilters(StrawberryDjangoFieldBase):
                 and is_root_query
                 and not self.is_list
                 and not self.is_connection
+                and not self.is_paginated
             ):
                 settings = strawberry_django_settings()
                 arguments.append(

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -1000,7 +1000,7 @@ def _get_model_hints(
             level=level,
         )
 
-    # In case this is a relay field, the selected fields are inside results selection
+    # In case this is a Paginated field, the selected fields are inside results selection
     if issubclass(object_definition.origin, Paginated):
         return _get_model_hints_from_paginated(
             model,

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -49,7 +49,7 @@ from strawberry.types.object_type import StrawberryObjectDefinition
 from typing_extensions import assert_never, assert_type
 
 from strawberry_django.fields.types import resolve_model_field_name
-from strawberry_django.pagination import apply_window_pagination
+from strawberry_django.pagination import Paginated, apply_window_pagination
 from strawberry_django.queryset import get_queryset_config, run_type_get_queryset
 from strawberry_django.relay import ListConnectionWithTotalCount
 from strawberry_django.resolvers import django_fetch
@@ -528,7 +528,7 @@ def _optimize_prefetch_queryset(
     )
     field_kwargs.pop("info", None)
 
-    # Disable the optimizer to avoid doint double optimization while running get_queryset
+    # Disable the optimizer to avoid doing double optimization while running get_queryset
     with DjangoOptimizerExtension.disabled():
         qs = field.get_queryset(
             qs,
@@ -573,6 +573,15 @@ def _optimize_prefetch_queryset(
                 )
             else:
                 mark_optimized = False
+
+        if isinstance(field.type, type) and issubclass(field.type, Paginated):
+            pagination = field_kwargs.get("pagination")
+            qs = apply_window_pagination(
+                qs,
+                related_field_id=related_field_id,
+                offset=pagination.offset if pagination else 0,
+                limit=pagination.limit if pagination else -1,
+            )
 
     if mark_optimized:
         qs = mark_optimized_by_prefetching(qs)
@@ -977,10 +986,23 @@ def _get_model_hints(
 ) -> OptimizerStore | None:
     cache = cache or {}
 
-    # In case this is a relay field, find the selected edges/nodes, the selected fields
-    # are actually inside edges -> node selection...
+    # In case this is a relay field, the selected fields are inside edges -> node selection
     if issubclass(object_definition.origin, relay.Connection):
         return _get_model_hints_from_connection(
+            model,
+            schema,
+            object_definition,
+            parent_type=parent_type,
+            info=info,
+            config=config,
+            prefix=prefix,
+            cache=cache,
+            level=level,
+        )
+
+    # In case this is a relay field, the selected fields are inside results selection
+    if issubclass(object_definition.origin, Paginated):
+        return _get_model_hints_from_paginated(
             model,
             schema,
             object_definition,
@@ -1152,6 +1174,55 @@ def _get_model_hints_from_connection(
                 cache=cache,
                 level=level,
             )
+
+    return store
+
+
+def _get_model_hints_from_paginated(
+    model: type[models.Model],
+    schema: Schema,
+    object_definition: StrawberryObjectDefinition,
+    *,
+    parent_type: GraphQLObjectType | GraphQLInterfaceType,
+    info: GraphQLResolveInfo,
+    config: OptimizerConfig | None = None,
+    prefix: str = "",
+    cache: dict[type[models.Model], list[tuple[int, OptimizerStore]]] | None = None,
+    level: int = 0,
+) -> OptimizerStore | None:
+    store = None
+
+    n_type = object_definition.type_var_map.get("NodeType")
+    n_definition = get_object_definition(n_type, strict=True)
+    n_gql_definition = _get_gql_definition(
+        schema,
+        get_object_definition(n_type, strict=True),
+    )
+    assert isinstance(n_gql_definition, (GraphQLObjectType, GraphQLInterfaceType))
+
+    for selections in _get_selections(info, parent_type).values():
+        selection = selections[0]
+        if selection.name.value != "results":
+            continue
+
+        n_info = _generate_selection_resolve_info(
+            info,
+            selections,
+            n_gql_definition,
+            n_gql_definition,
+        )
+
+        store = _get_model_hints(
+            model=model,
+            schema=schema,
+            object_definition=n_definition,
+            parent_type=n_gql_definition,
+            info=n_info,
+            config=config,
+            prefix=prefix,
+            cache=cache,
+            level=level,
+        )
 
     return store
 

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -49,7 +49,7 @@ from strawberry.types.object_type import StrawberryObjectDefinition
 from typing_extensions import assert_never, assert_type
 
 from strawberry_django.fields.types import resolve_model_field_name
-from strawberry_django.pagination import Paginated, apply_window_pagination
+from strawberry_django.pagination import OffsetPaginated, apply_window_pagination
 from strawberry_django.queryset import get_queryset_config, run_type_get_queryset
 from strawberry_django.relay import ListConnectionWithTotalCount
 from strawberry_django.resolvers import django_fetch
@@ -574,7 +574,7 @@ def _optimize_prefetch_queryset(
             else:
                 mark_optimized = False
 
-        if isinstance(field.type, type) and issubclass(field.type, Paginated):
+        if isinstance(field.type, type) and issubclass(field.type, OffsetPaginated):
             pagination = field_kwargs.get("pagination")
             qs = apply_window_pagination(
                 qs,
@@ -1001,7 +1001,7 @@ def _get_model_hints(
         )
 
     # In case this is a Paginated field, the selected fields are inside results selection
-    if issubclass(object_definition.origin, Paginated):
+    if issubclass(object_definition.origin, OffsetPaginated):
         return _get_model_hints_from_paginated(
             model,
             schema,

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -28,19 +28,19 @@ class OffsetPaginationInput:
 
 
 @strawberry.type
-class PaginatedInfo:
+class OffsetPaginationInfo:
     offset: int = 0
     limit: Optional[int] = None
 
 
 @strawberry.type
-class Paginated(Generic[NodeType]):
+class OffsetPaginated(Generic[NodeType]):
     queryset: strawberry.Private[Optional[QuerySet]]
     pagination: strawberry.Private[OffsetPaginationInput]
 
     @strawberry.field
-    def page_info(self) -> PaginatedInfo:
-        return PaginatedInfo(
+    def page_info(self) -> OffsetPaginationInfo:
+        return OffsetPaginationInfo(
             limit=self.pagination.limit,
             offset=self.pagination.offset,
         )
@@ -320,7 +320,7 @@ class StrawberryDjangoPagination(StrawberryDjangoFieldBase):
         *,
         pagination: Optional[object] = None,
         **kwargs,
-    ) -> Union[_T, Paginated[_T]]:
+    ) -> Union[_T, OffsetPaginated[_T]]:
         if not self.is_paginated:
             return result
 
@@ -333,7 +333,7 @@ class StrawberryDjangoPagination(StrawberryDjangoFieldBase):
         ):
             raise TypeError(f"Don't know how to resolve pagination {pagination!r}")
 
-        return Paginated(
+        return OffsetPaginated(
             queryset=result,
             pagination=pagination or OffsetPaginationInput(),
         )

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -20,20 +20,17 @@ NodeType = TypeVar("NodeType")
 _T = TypeVar("_T")
 _QS = TypeVar("_QS", bound=QuerySet)
 
-DEFAULT_OFFSET: int = 0
-DEFAULT_LIMIT: int = -1
-
 
 @strawberry.input
 class OffsetPaginationInput:
-    offset: int = DEFAULT_OFFSET
-    limit: int = DEFAULT_LIMIT
+    offset: int = 0
+    limit: Optional[int] = None
 
 
 @strawberry.type
 class PaginatedInfo:
-    limit: int
-    offset: int
+    offset: int = 0
+    limit: Optional[int] = None
 
 
 @strawberry.type
@@ -117,7 +114,7 @@ def apply(
         )
     else:
         start = pagination.offset
-        if pagination.limit >= 0:
+        if pagination.limit is not None and pagination.limit >= 0:
             stop = start + pagination.limit
             queryset = queryset[start:stop]
         else:
@@ -140,7 +137,7 @@ def apply_window_pagination(
     *,
     related_field_id: str,
     offset: int = 0,
-    limit: int = -1,
+    limit: Optional[int] = None,
 ) -> _QS:
     """Apply pagination using window functions.
 
@@ -181,7 +178,7 @@ def apply_window_pagination(
 
     # Limit == -1 means no limit. sys.maxsize is set by relay when paginating
     # from the end to as a way to mimic a "not limit" as well
-    if limit >= 0 and limit != sys.maxsize:
+    if limit is not None and limit >= 0 and limit != sys.maxsize:
         queryset = queryset.filter(_strawberry_row_number__lte=offset + limit)
 
     return queryset

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -17,8 +17,9 @@ from strawberry_django.resolvers import django_resolver
 from .arguments import argument
 
 NodeType = TypeVar("NodeType")
-_T = TypeVar("_T")
 _QS = TypeVar("_QS", bound=QuerySet)
+
+PAGINATION_ARG = "pagination"
 
 
 @strawberry.input
@@ -337,35 +338,4 @@ class StrawberryDjangoPagination(StrawberryDjangoFieldBase):
             queryset,
             pagination,
             related_field_id=_strawberry_related_field_id,
-        )
-
-    def get_wrapped_result(
-        self,
-        result: _T,
-        info: Info,
-        *,
-        pagination: Optional[OffsetPaginationInput] = None,
-        **kwargs,
-    ) -> Union[_T, OffsetPaginated[_T]]:
-        if not self.is_paginated:
-            return result
-
-        if not isinstance(result, QuerySet):
-            raise TypeError(f"Result expected to be a queryset, got {result!r}")
-
-        if (
-            pagination not in (None, UNSET)  # noqa: PLR6201
-            and not isinstance(pagination, OffsetPaginationInput)
-        ):
-            raise TypeError(f"Don't know how to resolve pagination {pagination!r}")
-
-        paginated_type = self.type
-        assert isinstance(paginated_type, type)
-        assert issubclass(paginated_type, OffsetPaginated)
-
-        return paginated_type.resolve_paginated(
-            result,
-            info=info,
-            pagination=pagination,
-            **kwargs,
         )

--- a/strawberry_django/permissions.py
+++ b/strawberry_django/permissions.py
@@ -39,7 +39,7 @@ from typing_extensions import Literal, assert_never
 
 from strawberry_django.auth.utils import aget_current_user, get_current_user
 from strawberry_django.fields.types import OperationInfo, OperationMessage
-from strawberry_django.pagination import OffsetPaginated, OffsetPaginationInput
+from strawberry_django.pagination import OffsetPaginated
 from strawberry_django.resolvers import django_resolver
 
 from .utils.query import filter_for_user
@@ -47,6 +47,8 @@ from .utils.typing import UserType
 
 if TYPE_CHECKING:
     from strawberry.django.context import StrawberryDjangoContext
+
+    from strawberry_django.fields.field import StrawberryDjangoField
 
 
 _M = TypeVar("_M", bound=Model)
@@ -407,7 +409,9 @@ class DjangoPermissionExtension(FieldExtension, abc.ABC):
             return []
 
         if isinstance(ret_type, type) and issubclass(ret_type, OffsetPaginated):
-            return OffsetPaginated(queryset=None, pagination=OffsetPaginationInput())
+            django_model = cast("StrawberryDjangoField", info._field).django_model
+            assert django_model
+            return django_model._default_manager.none()
 
         # If it is a Connection, try to return an empty connection, but only if
         # it is the only possibility available...

--- a/strawberry_django/permissions.py
+++ b/strawberry_django/permissions.py
@@ -39,6 +39,7 @@ from typing_extensions import Literal, assert_never
 
 from strawberry_django.auth.utils import aget_current_user, get_current_user
 from strawberry_django.fields.types import OperationInfo, OperationMessage
+from strawberry_django.pagination import OffsetPaginationInput, Paginated
 from strawberry_django.resolvers import django_resolver
 
 from .utils.query import filter_for_user
@@ -404,6 +405,9 @@ class DjangoPermissionExtension(FieldExtension, abc.ABC):
 
         if isinstance(ret_type, StrawberryList):
             return []
+
+        if isinstance(ret_type, type) and issubclass(ret_type, Paginated):
+            return Paginated(queryset=None, pagination=OffsetPaginationInput())
 
         # If it is a Connection, try to return an empty connection, but only if
         # it is the only possibility available...

--- a/strawberry_django/permissions.py
+++ b/strawberry_django/permissions.py
@@ -39,7 +39,7 @@ from typing_extensions import Literal, assert_never
 
 from strawberry_django.auth.utils import aget_current_user, get_current_user
 from strawberry_django.fields.types import OperationInfo, OperationMessage
-from strawberry_django.pagination import OffsetPaginationInput, Paginated
+from strawberry_django.pagination import OffsetPaginated, OffsetPaginationInput
 from strawberry_django.resolvers import django_resolver
 
 from .utils.query import filter_for_user
@@ -406,8 +406,8 @@ class DjangoPermissionExtension(FieldExtension, abc.ABC):
         if isinstance(ret_type, StrawberryList):
             return []
 
-        if isinstance(ret_type, type) and issubclass(ret_type, Paginated):
-            return Paginated(queryset=None, pagination=OffsetPaginationInput())
+        if isinstance(ret_type, type) and issubclass(ret_type, OffsetPaginated):
+            return OffsetPaginated(queryset=None, pagination=OffsetPaginationInput())
 
         # If it is a Connection, try to return an empty connection, but only if
         # it is the only possibility available...

--- a/strawberry_django/resolvers.py
+++ b/strawberry_django/resolvers.py
@@ -193,7 +193,7 @@ def resolve_base_manager(manager: BaseManager) -> Any:
         # prevents us from importing and checking isinstance on them directly.
         try:
             # ManyRelatedManager
-            return list(prefetched_cache[manager.prefetch_cache_name])  # type: ignore
+            return prefetched_cache[manager.prefetch_cache_name]  # type: ignore
         except (AttributeError, KeyError):
             try:
                 # RelatedManager
@@ -203,7 +203,7 @@ def resolve_base_manager(manager: BaseManager) -> Any:
                     getattr(result_field.remote_field, "cache_name", None)
                     or result_field.remote_field.get_cache_name()
                 )
-                return list(prefetched_cache[cache_name])
+                return prefetched_cache[cache_name]
             except (AttributeError, KeyError):
                 pass
 

--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -1,6 +1,6 @@
 """Code for interacting with Django settings."""
 
-from typing import cast
+from typing import Optional, cast
 
 from django.conf import settings
 from typing_extensions import TypedDict
@@ -42,6 +42,10 @@ class StrawberryDjangoSettings(TypedDict):
     #: If True, deprecated way of using filters will be working
     USE_DEPRECATED_FILTERS: bool
 
+    #: The default limit for pagination when not provided. Can be set to `None`
+    #: to set it to unlimited.
+    PAGINATION_DEFAULT_LIMIT: Optional[int]
+
 
 DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
     FIELD_DESCRIPTION_FROM_HELP_TEXT=False,
@@ -52,6 +56,7 @@ DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
     MAP_AUTO_ID_AS_GLOBAL_ID=False,
     DEFAULT_PK_FIELD_NAME="pk",
     USE_DEPRECATED_FILTERS=False,
+    PAGINATION_DEFAULT_LIMIT=100,
 )
 
 

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -55,12 +55,12 @@ from .fields.field import field as _field
 from .fields.types import get_model_field, resolve_model_field_name
 from .settings import strawberry_django_settings as django_settings
 
-__all = [
-    "StrawberryDjangoType",
-    "type",
-    "interface",
+__all__ = [
+    "StrawberryDjangoDefinition",
     "input",
+    "interface",
     "partial",
+    "type",
 ]
 
 _T = TypeVar("_T", bound=type)

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -29,6 +29,7 @@ from strawberry_django.auth.queries import get_current_user
 from strawberry_django.fields.types import ListInput, NodeInput, NodeInputPartial
 from strawberry_django.mutations import resolvers
 from strawberry_django.optimizer import DjangoOptimizerExtension
+from strawberry_django.pagination import Paginated
 from strawberry_django.permissions import (
     HasPerm,
     HasRetvalPerm,
@@ -157,6 +158,10 @@ class MilestoneType(relay.Node, Named):
         filters=IssueFilter,
         order=IssueOrder,
         pagination=True,
+    )
+    issues_paginated: Paginated["IssueType"] = strawberry_django.field(
+        field_name="issues",
+        order=IssueOrder,
     )
     issues_with_filters: ListConnectionWithTotalCount["IssueType"] = (
         strawberry_django.connection(
@@ -375,6 +380,7 @@ class Query:
     staff_list: list[Optional[StaffType]] = strawberry_django.node()
 
     issue_list: list[IssueType] = strawberry_django.field()
+    issues_paginated: Paginated[IssueType] = strawberry_django.field()
     milestone_list: list[MilestoneType] = strawberry_django.field(
         order=MilestoneOrder,
         filters=MilestoneFilter,
@@ -429,6 +435,9 @@ class Query:
     issue_list_perm_required: list[IssueType] = strawberry_django.field(
         extensions=[HasPerm(perms=["projects.view_issue"])],
     )
+    issue_paginated_list_perm_required: Paginated[IssueType] = strawberry_django.field(
+        extensions=[HasPerm(perms=["projects.view_issue"])],
+    )
     issue_conn_perm_required: ListConnectionWithTotalCount[IssueType] = (
         strawberry_django.connection(
             extensions=[HasPerm(perms=["projects.view_issue"])],
@@ -446,6 +455,11 @@ class Query:
     )
     issue_list_obj_perm_required_paginated: list[IssueType] = strawberry_django.field(
         extensions=[HasRetvalPerm(perms=["projects.view_issue"])], pagination=True
+    )
+    issue_paginated_list_obj_perm_required_paginated: Paginated[IssueType] = (
+        strawberry_django.field(
+            extensions=[HasRetvalPerm(perms=["projects.view_issue"])], pagination=True
+        )
     )
     issue_conn_obj_perm_required: ListConnectionWithTotalCount[IssueType] = (
         strawberry_django.connection(

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -435,7 +435,7 @@ class Query:
     issue_list_perm_required: list[IssueType] = strawberry_django.field(
         extensions=[HasPerm(perms=["projects.view_issue"])],
     )
-    issue_paginated_list_perm_required: Paginated[IssueType] = strawberry_django.field(
+    issues_paginated_perm_required: Paginated[IssueType] = strawberry_django.field(
         extensions=[HasPerm(perms=["projects.view_issue"])],
     )
     issue_conn_perm_required: ListConnectionWithTotalCount[IssueType] = (
@@ -456,10 +456,8 @@ class Query:
     issue_list_obj_perm_required_paginated: list[IssueType] = strawberry_django.field(
         extensions=[HasRetvalPerm(perms=["projects.view_issue"])], pagination=True
     )
-    issue_paginated_list_obj_perm_required_paginated: Paginated[IssueType] = (
-        strawberry_django.field(
-            extensions=[HasRetvalPerm(perms=["projects.view_issue"])], pagination=True
-        )
+    issues_paginated_obj_perm_required: Paginated[IssueType] = strawberry_django.field(
+        extensions=[HasRetvalPerm(perms=["projects.view_issue"])],
     )
     issue_conn_obj_perm_required: ListConnectionWithTotalCount[IssueType] = (
         strawberry_django.connection(

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -159,7 +159,7 @@ class MilestoneType(relay.Node, Named):
         order=IssueOrder,
         pagination=True,
     )
-    issues_paginated: OffsetPaginated["IssueType"] = strawberry_django.field(
+    issues_paginated: OffsetPaginated["IssueType"] = strawberry_django.offset_paginated(
         field_name="issues",
         order=IssueOrder,
     )
@@ -380,7 +380,7 @@ class Query:
     staff_list: list[Optional[StaffType]] = strawberry_django.node()
 
     issue_list: list[IssueType] = strawberry_django.field()
-    issues_paginated: OffsetPaginated[IssueType] = strawberry_django.field()
+    issues_paginated: OffsetPaginated[IssueType] = strawberry_django.offset_paginated()
     milestone_list: list[MilestoneType] = strawberry_django.field(
         order=MilestoneOrder,
         filters=MilestoneFilter,
@@ -436,7 +436,7 @@ class Query:
         extensions=[HasPerm(perms=["projects.view_issue"])],
     )
     issues_paginated_perm_required: OffsetPaginated[IssueType] = (
-        strawberry_django.field(
+        strawberry_django.offset_paginated(
             extensions=[HasPerm(perms=["projects.view_issue"])],
         )
     )
@@ -459,7 +459,7 @@ class Query:
         extensions=[HasRetvalPerm(perms=["projects.view_issue"])], pagination=True
     )
     issues_paginated_obj_perm_required: OffsetPaginated[IssueType] = (
-        strawberry_django.field(
+        strawberry_django.offset_paginated(
             extensions=[HasRetvalPerm(perms=["projects.view_issue"])],
         )
     )

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -29,7 +29,7 @@ from strawberry_django.auth.queries import get_current_user
 from strawberry_django.fields.types import ListInput, NodeInput, NodeInputPartial
 from strawberry_django.mutations import resolvers
 from strawberry_django.optimizer import DjangoOptimizerExtension
-from strawberry_django.pagination import Paginated
+from strawberry_django.pagination import OffsetPaginated
 from strawberry_django.permissions import (
     HasPerm,
     HasRetvalPerm,
@@ -159,7 +159,7 @@ class MilestoneType(relay.Node, Named):
         order=IssueOrder,
         pagination=True,
     )
-    issues_paginated: Paginated["IssueType"] = strawberry_django.field(
+    issues_paginated: OffsetPaginated["IssueType"] = strawberry_django.field(
         field_name="issues",
         order=IssueOrder,
     )
@@ -380,7 +380,7 @@ class Query:
     staff_list: list[Optional[StaffType]] = strawberry_django.node()
 
     issue_list: list[IssueType] = strawberry_django.field()
-    issues_paginated: Paginated[IssueType] = strawberry_django.field()
+    issues_paginated: OffsetPaginated[IssueType] = strawberry_django.field()
     milestone_list: list[MilestoneType] = strawberry_django.field(
         order=MilestoneOrder,
         filters=MilestoneFilter,
@@ -435,8 +435,10 @@ class Query:
     issue_list_perm_required: list[IssueType] = strawberry_django.field(
         extensions=[HasPerm(perms=["projects.view_issue"])],
     )
-    issues_paginated_perm_required: Paginated[IssueType] = strawberry_django.field(
-        extensions=[HasPerm(perms=["projects.view_issue"])],
+    issues_paginated_perm_required: OffsetPaginated[IssueType] = (
+        strawberry_django.field(
+            extensions=[HasPerm(perms=["projects.view_issue"])],
+        )
     )
     issue_conn_perm_required: ListConnectionWithTotalCount[IssueType] = (
         strawberry_django.connection(
@@ -456,8 +458,10 @@ class Query:
     issue_list_obj_perm_required_paginated: list[IssueType] = strawberry_django.field(
         extensions=[HasRetvalPerm(perms=["projects.view_issue"])], pagination=True
     )
-    issues_paginated_obj_perm_required: Paginated[IssueType] = strawberry_django.field(
-        extensions=[HasRetvalPerm(perms=["projects.view_issue"])],
+    issues_paginated_obj_perm_required: OffsetPaginated[IssueType] = (
+        strawberry_django.field(
+            extensions=[HasRetvalPerm(perms=["projects.view_issue"])],
+        )
     )
     issue_conn_obj_perm_required: ListConnectionWithTotalCount[IssueType] = (
         strawberry_django.connection(

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -336,6 +336,17 @@ type IssueTypeEdge {
   node: IssueType!
 }
 
+type IssueTypePaginated {
+  limit: Int!
+  offset: Int!
+
+  """Total count of existing results."""
+  totalCount: Int!
+
+  """List of paginated results."""
+  results: [IssueType!]!
+}
+
 input MilestoneFilter {
   name: StrFilterLookup
   project: DjangoModelFilterInput
@@ -373,6 +384,7 @@ type MilestoneType implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
+  issuesPaginated(pagination: OffsetPaginationInput): IssueTypePaginated!
   issuesWithFilters(
     filters: IssueFilter
 
@@ -610,6 +622,7 @@ type Query {
     ids: [GlobalID!]!
   ): [StaffType]!
   issueList: [IssueType!]!
+  issuesPaginated(pagination: OffsetPaginationInput): IssueTypePaginated!
   milestoneList(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
   projectList(filters: ProjectFilter): [ProjectType!]!
   tagList: [TagType!]!
@@ -729,6 +742,7 @@ type Query {
     id: GlobalID!
   ): IssueType @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListPermRequired: [IssueType!]! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
+  issuePaginatedListPermRequired(pagination: OffsetPaginationInput): IssueTypePaginated! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueConnPermRequired(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null
@@ -752,6 +766,7 @@ type Query {
   ): IssueType @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListObjPermRequired: [IssueType!]! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListObjPermRequiredPaginated(pagination: OffsetPaginationInput): [IssueType!]! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
+  issuePaginatedListObjPermRequiredPaginated(pagination: OffsetPaginationInput): IssueTypePaginated! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueConnObjPermRequired(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -336,8 +336,8 @@ type IssueTypeEdge {
   node: IssueType!
 }
 
-type IssueTypePaginated {
-  pageInfo: PaginatedInfo!
+type IssueTypeOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
 
   """Total count of existing results."""
   totalCount: Int!
@@ -383,7 +383,7 @@ type MilestoneType implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
-  issuesPaginated(pagination: OffsetPaginationInput): IssueTypePaginated!
+  issuesPaginated(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter
 
@@ -463,6 +463,11 @@ input NodeInputPartial {
   id: GlobalID
 }
 
+type OffsetPaginationInfo {
+  offset: Int!
+  limit: Int
+}
+
 input OffsetPaginationInput {
   offset: Int! = 0
   limit: Int = null
@@ -519,11 +524,6 @@ type PageInfo {
 
   """When paginating forwards, the cursor to continue."""
   endCursor: String
-}
-
-type PaginatedInfo {
-  offset: Int!
-  limit: Int
 }
 
 type ProjectConnection {
@@ -626,7 +626,7 @@ type Query {
     ids: [GlobalID!]!
   ): [StaffType]!
   issueList: [IssueType!]!
-  issuesPaginated(pagination: OffsetPaginationInput): IssueTypePaginated!
+  issuesPaginated(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated!
   milestoneList(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
   projectList(filters: ProjectFilter): [ProjectType!]!
   tagList: [TagType!]!
@@ -746,7 +746,7 @@ type Query {
     id: GlobalID!
   ): IssueType @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListPermRequired: [IssueType!]! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
-  issuesPaginatedPermRequired(pagination: OffsetPaginationInput): IssueTypePaginated! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
+  issuesPaginatedPermRequired(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueConnPermRequired(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null
@@ -770,7 +770,7 @@ type Query {
   ): IssueType @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListObjPermRequired: [IssueType!]! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListObjPermRequiredPaginated(pagination: OffsetPaginationInput): [IssueType!]! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
-  issuesPaginatedObjPermRequired(pagination: OffsetPaginationInput): IssueTypePaginated! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
+  issuesPaginatedObjPermRequired(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueConnObjPermRequired(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -742,7 +742,7 @@ type Query {
     id: GlobalID!
   ): IssueType @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListPermRequired: [IssueType!]! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
-  issuePaginatedListPermRequired(pagination: OffsetPaginationInput): IssueTypePaginated! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
+  issuesPaginatedPermRequired(pagination: OffsetPaginationInput): IssueTypePaginated! @hasPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueConnPermRequired(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null
@@ -766,7 +766,7 @@ type Query {
   ): IssueType @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListObjPermRequired: [IssueType!]! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueListObjPermRequiredPaginated(pagination: OffsetPaginationInput): [IssueType!]! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
-  issuePaginatedListObjPermRequiredPaginated(pagination: OffsetPaginationInput): IssueTypePaginated! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
+  issuesPaginatedObjPermRequired(pagination: OffsetPaginationInput): IssueTypePaginated! @hasRetvalPerm(permissions: [{app: "projects", permission: "view_issue"}], any: true)
   issueConnObjPermRequired(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -465,7 +465,7 @@ input NodeInputPartial {
 
 input OffsetPaginationInput {
   offset: Int! = 0
-  limit: Int! = -1
+  limit: Int = null
 }
 
 type OperationInfo {
@@ -522,8 +522,8 @@ type PageInfo {
 }
 
 type PaginatedInfo {
-  limit: Int!
   offset: Int!
+  limit: Int
 }
 
 type ProjectConnection {

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -337,8 +337,7 @@ type IssueTypeEdge {
 }
 
 type IssueTypePaginated {
-  limit: Int!
-  offset: Int!
+  pageInfo: PaginatedInfo!
 
   """Total count of existing results."""
   totalCount: Int!
@@ -520,6 +519,11 @@ type PageInfo {
 
   """When paginating forwards, the cursor to continue."""
   endCursor: String
+}
+
+type PaginatedInfo {
+  limit: Int!
+  offset: Int!
 }
 
 type ProjectConnection {

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -383,7 +383,7 @@ type MilestoneType implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
-  issuesPaginated(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated!
+  issuesPaginated(pagination: OffsetPaginationInput, order: IssueOrder): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter
 

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -137,8 +137,7 @@ type IssueTypeEdge {
 }
 
 type IssueTypePaginated {
-  limit: Int!
-  offset: Int!
+  pageInfo: PaginatedInfo!
 
   """Total count of existing results."""
   totalCount: Int!
@@ -298,6 +297,11 @@ type PageInfo {
 
   """When paginating forwards, the cursor to continue."""
   endCursor: String
+}
+
+type PaginatedInfo {
+  limit: Int!
+  offset: Int!
 }
 
 input ProjectOrder {

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -173,7 +173,7 @@ type MilestoneType implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
-  issuesPaginated(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated!
+  issuesPaginated(pagination: OffsetPaginationInput, order: IssueOrder): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter
 
@@ -201,7 +201,7 @@ type MilestoneTypeSubclass implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
-  issuesPaginated(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated!
+  issuesPaginated(pagination: OffsetPaginationInput, order: IssueOrder): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter
 

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -243,7 +243,7 @@ input NodeInput {
 
 input OffsetPaginationInput {
   offset: Int! = 0
-  limit: Int! = -1
+  limit: Int = null
 }
 
 type OperationInfo {
@@ -300,8 +300,8 @@ type PageInfo {
 }
 
 type PaginatedInfo {
-  limit: Int!
   offset: Int!
+  limit: Int
 }
 
 input ProjectOrder {

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -136,6 +136,17 @@ type IssueTypeEdge {
   node: IssueType!
 }
 
+type IssueTypePaginated {
+  limit: Int!
+  offset: Int!
+
+  """Total count of existing results."""
+  totalCount: Int!
+
+  """List of paginated results."""
+  results: [IssueType!]!
+}
+
 input MilestoneFilter {
   name: StrFilterLookup
   project: DjangoModelFilterInput
@@ -163,6 +174,7 @@ type MilestoneType implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
+  issuesPaginated(pagination: OffsetPaginationInput): IssueTypePaginated!
   issuesWithFilters(
     filters: IssueFilter
 
@@ -190,6 +202,7 @@ type MilestoneTypeSubclass implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
+  issuesPaginated(pagination: OffsetPaginationInput): IssueTypePaginated!
   issuesWithFilters(
     filters: IssueFilter
 

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -136,8 +136,8 @@ type IssueTypeEdge {
   node: IssueType!
 }
 
-type IssueTypePaginated {
-  pageInfo: PaginatedInfo!
+type IssueTypeOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
 
   """Total count of existing results."""
   totalCount: Int!
@@ -173,7 +173,7 @@ type MilestoneType implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
-  issuesPaginated(pagination: OffsetPaginationInput): IssueTypePaginated!
+  issuesPaginated(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter
 
@@ -201,7 +201,7 @@ type MilestoneTypeSubclass implements Node & Named {
   dueDate: Date
   project: ProjectType!
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
-  issuesPaginated(pagination: OffsetPaginationInput): IssueTypePaginated!
+  issuesPaginated(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter
 
@@ -239,6 +239,11 @@ interface Node {
 """Input of an object that implements the `Node` interface."""
 input NodeInput {
   id: GlobalID!
+}
+
+type OffsetPaginationInfo {
+  offset: Int!
+  limit: Int
 }
 
 input OffsetPaginationInput {
@@ -297,11 +302,6 @@ type PageInfo {
 
   """When paginating forwards, the cursor to continue."""
   endCursor: String
-}
-
-type PaginatedInfo {
-  offset: Int!
-  limit: Int
 }
 
 input ProjectOrder {

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -2,6 +2,7 @@ import textwrap
 
 import pytest
 import strawberry
+from django.db.models import QuerySet
 
 import strawberry_django
 from strawberry_django.pagination import OffsetPaginated, OffsetPaginationInput
@@ -22,8 +23,8 @@ def test_paginated_schema():
 
     @strawberry.type
     class Query:
-        fruits: OffsetPaginated[Fruit] = strawberry_django.field()
-        colors: OffsetPaginated[Color] = strawberry_django.field()
+        fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated()
+        colors: OffsetPaginated[Color] = strawberry_django.offset_paginated()
 
     schema = strawberry.Schema(query=Query)
 
@@ -87,7 +88,7 @@ def test_pagination_query():
 
     @strawberry.type
     class Query:
-        fruits: OffsetPaginated[Fruit] = strawberry_django.field()
+        fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated()
 
     models.Fruit.objects.create(name="Apple")
     models.Fruit.objects.create(name="Banana")
@@ -145,7 +146,7 @@ async def test_pagination_query_async():
 
     @strawberry.type
     class Query:
-        fruits: OffsetPaginated[Fruit] = strawberry_django.field()
+        fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated()
 
     await models.Fruit.objects.acreate(name="Apple")
     await models.Fruit.objects.acreate(name="Banana")
@@ -205,11 +206,11 @@ def test_pagination_nested_query():
     class Color:
         id: int
         name: str
-        fruits: OffsetPaginated[Fruit]
+        fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated()
 
     @strawberry.type
     class Query:
-        colors: OffsetPaginated[Color] = strawberry_django.field()
+        colors: OffsetPaginated[Color] = strawberry_django.offset_paginated()
 
     red = models.Color.objects.create(name="Red")
     yellow = models.Color.objects.create(name="Yellow")
@@ -316,11 +317,11 @@ async def test_pagination_nested_query_async():
     class Color:
         id: int
         name: str
-        fruits: OffsetPaginated[Fruit]
+        fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated()
 
     @strawberry.type
     class Query:
-        colors: OffsetPaginated[Color] = strawberry_django.field()
+        colors: OffsetPaginated[Color] = strawberry_django.offset_paginated()
 
     red = await models.Color.objects.acreate(name="Red")
     yellow = await models.Color.objects.acreate(name="Yellow")
@@ -441,7 +442,7 @@ def test_pagination_query_with_subclass():
 
     @strawberry.type
     class Query:
-        fruits: FruitPaginated = strawberry_django.field()
+        fruits: FruitPaginated = strawberry_django.offset_paginated()
 
     models.Fruit.objects.create(name="Apple")
     models.Fruit.objects.create(name="Banana")
@@ -491,4 +492,340 @@ def test_pagination_query_with_subclass():
             "customField": "pagination rocks",
             "results": [{"name": "Strawberry"}],
         }
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pagination_query_with_resolver_schema():
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry_django.filter(models.Fruit)
+    class FruitFilter:
+        name: str
+
+    @strawberry_django.order(models.Fruit)
+    class FruitOrder:
+        name: str
+
+    @strawberry.type
+    class Query:
+        @strawberry_django.offset_paginated(OffsetPaginated[Fruit])
+        def fruits(self) -> QuerySet[models.Fruit]: ...
+
+        @strawberry_django.offset_paginated(
+            OffsetPaginated[Fruit],
+            filters=FruitFilter,
+            order=FruitOrder,
+        )
+        def fruits_with_order_and_filter(self) -> QuerySet[models.Fruit]: ...
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = '''
+    type Fruit {
+      id: Int!
+      name: String!
+    }
+
+    input FruitFilter {
+      name: String!
+      AND: FruitFilter
+      OR: FruitFilter
+      NOT: FruitFilter
+      DISTINCT: Boolean
+    }
+
+    type FruitOffsetPaginated {
+      pageInfo: OffsetPaginationInfo!
+
+      """Total count of existing results."""
+      totalCount: Int!
+
+      """List of paginated results."""
+      results: [Fruit!]!
+    }
+
+    input FruitOrder {
+      name: String
+    }
+
+    type OffsetPaginationInfo {
+      offset: Int!
+      limit: Int
+    }
+
+    input OffsetPaginationInput {
+      offset: Int! = 0
+      limit: Int = null
+    }
+
+    type Query {
+      fruits(pagination: OffsetPaginationInput): FruitOffsetPaginated!
+      fruitsWithOrderAndFilter(filters: FruitFilter, order: FruitOrder, pagination: OffsetPaginationInput): FruitOffsetPaginated!
+    }
+    '''
+
+    assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pagination_query_with_resolver():
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry_django.filter(models.Fruit)
+    class FruitFilter:
+        name: strawberry.auto
+
+    @strawberry_django.order(models.Fruit)
+    class FruitOrder:
+        name: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        @strawberry_django.offset_paginated(OffsetPaginated[Fruit])
+        def fruits(self) -> QuerySet[models.Fruit]:
+            return models.Fruit.objects.filter(name__startswith="S")
+
+        @strawberry_django.offset_paginated(
+            OffsetPaginated[Fruit],
+            filters=FruitFilter,
+            order=FruitOrder,
+        )
+        def fruits_with_order_and_filter(self) -> QuerySet[models.Fruit]:
+            return models.Fruit.objects.filter(name__startswith="S")
+
+    models.Fruit.objects.create(name="Apple")
+    models.Fruit.objects.create(name="Strawberry")
+    models.Fruit.objects.create(name="Banana")
+    models.Fruit.objects.create(name="Sugar Apple")
+    models.Fruit.objects.create(name="Starfruit")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """\
+    query GetFruits (
+      $pagination: OffsetPaginationInput
+      $filters: FruitFilter
+      $order: FruitOrder
+    ) {
+      fruits (pagination: $pagination) {
+        totalCount
+        results {
+          name
+        }
+      }
+      fruitsWithOrderAndFilter (
+        pagination: $pagination
+        filters: $filters
+        order: $order
+      ) {
+        totalCount
+        results {
+          name
+        }
+      }
+    }
+    """
+
+    res = schema.execute_sync(query)
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+                {"name": "Sugar Apple"},
+                {"name": "Starfruit"},
+            ],
+        },
+        "fruitsWithOrderAndFilter": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+                {"name": "Sugar Apple"},
+                {"name": "Starfruit"},
+            ],
+        },
+    }
+
+    res = schema.execute_sync(query, variable_values={"pagination": {"limit": 1}})
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+            ],
+        },
+        "fruitsWithOrderAndFilter": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+            ],
+        },
+    }
+
+    res = schema.execute_sync(
+        query,
+        variable_values={
+            "pagination": {"limit": 2},
+            "order": {"name": "ASC"},
+            "filters": {"name": "Strawberry"},
+        },
+    )
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+                {"name": "Sugar Apple"},
+            ],
+        },
+        "fruitsWithOrderAndFilter": {
+            "totalCount": 1,
+            "results": [
+                {"name": "Strawberry"},
+            ],
+        },
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pagination_query_with_resolver_arguments():
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry_django.filter(models.Fruit)
+    class FruitFilter:
+        name: strawberry.auto
+
+    @strawberry_django.order(models.Fruit)
+    class FruitOrder:
+        name: strawberry.auto
+
+    @strawberry.type
+    class Query:
+        @strawberry_django.offset_paginated(OffsetPaginated[Fruit])
+        def fruits(self, starts_with: str) -> QuerySet[models.Fruit]:
+            return models.Fruit.objects.filter(name__startswith=starts_with)
+
+        @strawberry_django.offset_paginated(
+            OffsetPaginated[Fruit],
+            filters=FruitFilter,
+            order=FruitOrder,
+        )
+        def fruits_with_order_and_filter(
+            self, starts_with: str
+        ) -> QuerySet[models.Fruit]:
+            return models.Fruit.objects.filter(name__startswith=starts_with)
+
+    models.Fruit.objects.create(name="Apple")
+    models.Fruit.objects.create(name="Strawberry")
+    models.Fruit.objects.create(name="Banana")
+    models.Fruit.objects.create(name="Sugar Apple")
+    models.Fruit.objects.create(name="Starfruit")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """\
+    query GetFruits (
+      $pagination: OffsetPaginationInput
+      $filters: FruitFilter
+      $order: FruitOrder
+      $startsWith: String!
+    ) {
+      fruits (startsWith: $startsWith, pagination: $pagination) {
+        totalCount
+        results {
+          name
+        }
+      }
+      fruitsWithOrderAndFilter (
+        startsWith: $startsWith
+        pagination: $pagination
+        filters: $filters
+        order: $order
+      ) {
+        totalCount
+        results {
+          name
+        }
+      }
+    }
+    """
+
+    res = schema.execute_sync(query, variable_values={"startsWith": "S"})
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+                {"name": "Sugar Apple"},
+                {"name": "Starfruit"},
+            ],
+        },
+        "fruitsWithOrderAndFilter": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+                {"name": "Sugar Apple"},
+                {"name": "Starfruit"},
+            ],
+        },
+    }
+
+    res = schema.execute_sync(
+        query,
+        variable_values={"startsWith": "S", "pagination": {"limit": 1}},
+    )
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+            ],
+        },
+        "fruitsWithOrderAndFilter": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+            ],
+        },
+    }
+
+    res = schema.execute_sync(
+        query,
+        variable_values={
+            "startsWith": "S",
+            "pagination": {"limit": 2},
+            "order": {"name": "ASC"},
+            "filters": {"name": "Strawberry"},
+        },
+    )
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [
+                {"name": "Strawberry"},
+                {"name": "Sugar Apple"},
+            ],
+        },
+        "fruitsWithOrderAndFilter": {
+            "totalCount": 1,
+            "results": [
+                {"name": "Strawberry"},
+            ],
+        },
     }

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -8,7 +8,7 @@ from strawberry_django.pagination import Paginated
 from tests import models
 
 
-def test_pagination_schema():
+def test_paginated_schema():
     @strawberry_django.type(models.Fruit)
     class Fruit:
         id: int
@@ -35,8 +35,7 @@ def test_pagination_schema():
     }
 
     type ColorPaginated {
-      limit: Int!
-      offset: Int!
+      pageInfo: PaginatedInfo!
 
       """Total count of existing results."""
       totalCount: Int!
@@ -51,8 +50,7 @@ def test_pagination_schema():
     }
 
     type FruitPaginated {
-      limit: Int!
-      offset: Int!
+      pageInfo: PaginatedInfo!
 
       """Total count of existing results."""
       totalCount: Int!
@@ -64,6 +62,11 @@ def test_pagination_schema():
     input OffsetPaginationInput {
       offset: Int! = 0
       limit: Int! = -1
+    }
+
+    type PaginatedInfo {
+      limit: Int!
+      offset: Int!
     }
 
     type Query {

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -61,12 +61,12 @@ def test_paginated_schema():
 
     input OffsetPaginationInput {
       offset: Int! = 0
-      limit: Int! = -1
+      limit: Int = null
     }
 
     type PaginatedInfo {
-      limit: Int!
       offset: Int!
+      limit: Int
     }
 
     type Query {

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -4,7 +4,7 @@ import pytest
 import strawberry
 
 import strawberry_django
-from strawberry_django.pagination import Paginated
+from strawberry_django.pagination import OffsetPaginated
 from tests import models
 
 
@@ -18,12 +18,12 @@ def test_paginated_schema():
     class Color:
         id: int
         name: str
-        fruits: Paginated[Fruit]
+        fruits: OffsetPaginated[Fruit]
 
     @strawberry.type
     class Query:
-        fruits: Paginated[Fruit] = strawberry_django.field()
-        colors: Paginated[Color] = strawberry_django.field()
+        fruits: OffsetPaginated[Fruit] = strawberry_django.field()
+        colors: OffsetPaginated[Color] = strawberry_django.field()
 
     schema = strawberry.Schema(query=Query)
 
@@ -31,11 +31,11 @@ def test_paginated_schema():
     type Color {
       id: Int!
       name: String!
-      fruits(pagination: OffsetPaginationInput): FruitPaginated!
+      fruits(pagination: OffsetPaginationInput): FruitOffsetPaginated!
     }
 
-    type ColorPaginated {
-      pageInfo: PaginatedInfo!
+    type ColorOffsetPaginated {
+      pageInfo: OffsetPaginationInfo!
 
       """Total count of existing results."""
       totalCount: Int!
@@ -49,8 +49,8 @@ def test_paginated_schema():
       name: String!
     }
 
-    type FruitPaginated {
-      pageInfo: PaginatedInfo!
+    type FruitOffsetPaginated {
+      pageInfo: OffsetPaginationInfo!
 
       """Total count of existing results."""
       totalCount: Int!
@@ -59,19 +59,19 @@ def test_paginated_schema():
       results: [Fruit!]!
     }
 
+    type OffsetPaginationInfo {
+      offset: Int!
+      limit: Int
+    }
+
     input OffsetPaginationInput {
       offset: Int! = 0
       limit: Int = null
     }
 
-    type PaginatedInfo {
-      offset: Int!
-      limit: Int
-    }
-
     type Query {
-      fruits(pagination: OffsetPaginationInput): FruitPaginated!
-      colors(pagination: OffsetPaginationInput): ColorPaginated!
+      fruits(pagination: OffsetPaginationInput): FruitOffsetPaginated!
+      colors(pagination: OffsetPaginationInput): ColorOffsetPaginated!
     }
     '''
 
@@ -87,7 +87,7 @@ def test_pagination_query():
 
     @strawberry.type
     class Query:
-        fruits: Paginated[Fruit] = strawberry_django.field()
+        fruits: OffsetPaginated[Fruit] = strawberry_django.field()
 
     models.Fruit.objects.create(name="Apple")
     models.Fruit.objects.create(name="Banana")
@@ -145,7 +145,7 @@ async def test_pagination_query_async():
 
     @strawberry.type
     class Query:
-        fruits: Paginated[Fruit] = strawberry_django.field()
+        fruits: OffsetPaginated[Fruit] = strawberry_django.field()
 
     await models.Fruit.objects.acreate(name="Apple")
     await models.Fruit.objects.acreate(name="Banana")
@@ -205,11 +205,11 @@ def test_pagination_nested_query():
     class Color:
         id: int
         name: str
-        fruits: Paginated[Fruit]
+        fruits: OffsetPaginated[Fruit]
 
     @strawberry.type
     class Query:
-        colors: Paginated[Color] = strawberry_django.field()
+        colors: OffsetPaginated[Color] = strawberry_django.field()
 
     red = models.Color.objects.create(name="Red")
     yellow = models.Color.objects.create(name="Yellow")
@@ -316,11 +316,11 @@ async def test_pagination_nested_query_async():
     class Color:
         id: int
         name: str
-        fruits: Paginated[Fruit]
+        fruits: OffsetPaginated[Fruit]
 
     @strawberry.type
     class Query:
-        colors: Paginated[Color] = strawberry_django.field()
+        colors: OffsetPaginated[Color] = strawberry_django.field()
 
     red = await models.Color.objects.acreate(name="Red")
     yellow = await models.Color.objects.acreate(name="Yellow")

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -1,0 +1,413 @@
+import textwrap
+
+import pytest
+import strawberry
+
+import strawberry_django
+from strawberry_django.pagination import Paginated
+from tests import models
+
+
+def test_pagination_schema():
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry_django.type(models.Color)
+    class Color:
+        id: int
+        name: str
+        fruits: Paginated[Fruit]
+
+    @strawberry.type
+    class Query:
+        fruits: Paginated[Fruit] = strawberry_django.field()
+        colors: Paginated[Color] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query)
+
+    expected = '''\
+    type Color {
+      id: Int!
+      name: String!
+      fruits(pagination: OffsetPaginationInput): FruitPaginated!
+    }
+
+    type ColorPaginated {
+      limit: Int!
+      offset: Int!
+
+      """Total count of existing results."""
+      totalCount: Int!
+
+      """List of paginated results."""
+      results: [Color!]!
+    }
+
+    type Fruit {
+      id: Int!
+      name: String!
+    }
+
+    type FruitPaginated {
+      limit: Int!
+      offset: Int!
+
+      """Total count of existing results."""
+      totalCount: Int!
+
+      """List of paginated results."""
+      results: [Fruit!]!
+    }
+
+    input OffsetPaginationInput {
+      offset: Int! = 0
+      limit: Int! = -1
+    }
+
+    type Query {
+      fruits(pagination: OffsetPaginationInput): FruitPaginated!
+      colors(pagination: OffsetPaginationInput): ColorPaginated!
+    }
+    '''
+
+    assert textwrap.dedent(str(schema)) == textwrap.dedent(expected).strip()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pagination_query():
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry.type
+    class Query:
+        fruits: Paginated[Fruit] = strawberry_django.field()
+
+    models.Fruit.objects.create(name="Apple")
+    models.Fruit.objects.create(name="Banana")
+    models.Fruit.objects.create(name="Strawberry")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """\
+    query GetFruits ($pagination: OffsetPaginationInput) {
+      fruits (pagination: $pagination) {
+        totalCount
+        results {
+          name
+        }
+      }
+    }
+    """
+
+    res = schema.execute_sync(query)
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [{"name": "Apple"}, {"name": "Banana"}, {"name": "Strawberry"}],
+        }
+    }
+
+    res = schema.execute_sync(query, variable_values={"pagination": {"limit": 1}})
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [{"name": "Apple"}],
+        }
+    }
+
+    res = schema.execute_sync(
+        query, variable_values={"pagination": {"limit": 1, "offset": 1}}
+    )
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [{"name": "Banana"}],
+        }
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_pagination_query_async():
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry.type
+    class Query:
+        fruits: Paginated[Fruit] = strawberry_django.field()
+
+    await models.Fruit.objects.acreate(name="Apple")
+    await models.Fruit.objects.acreate(name="Banana")
+    await models.Fruit.objects.acreate(name="Strawberry")
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """\
+    query GetFruits ($pagination: OffsetPaginationInput) {
+      fruits (pagination: $pagination) {
+        totalCount
+        results {
+          name
+        }
+      }
+    }
+    """
+
+    res = await schema.execute(query)
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [{"name": "Apple"}, {"name": "Banana"}, {"name": "Strawberry"}],
+        }
+    }
+
+    res = await schema.execute(query, variable_values={"pagination": {"limit": 1}})
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [{"name": "Apple"}],
+        }
+    }
+
+    res = await schema.execute(
+        query, variable_values={"pagination": {"limit": 1, "offset": 1}}
+    )
+    assert res.errors is None
+    assert res.data == {
+        "fruits": {
+            "totalCount": 3,
+            "results": [{"name": "Banana"}],
+        }
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pagination_nested_query():
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry_django.type(models.Color)
+    class Color:
+        id: int
+        name: str
+        fruits: Paginated[Fruit]
+
+    @strawberry.type
+    class Query:
+        colors: Paginated[Color] = strawberry_django.field()
+
+    red = models.Color.objects.create(name="Red")
+    yellow = models.Color.objects.create(name="Yellow")
+
+    models.Fruit.objects.create(name="Apple", color=red)
+    models.Fruit.objects.create(name="Banana", color=yellow)
+    models.Fruit.objects.create(name="Strawberry", color=red)
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """\
+    query GetColors ($pagination: OffsetPaginationInput) {
+      colors {
+        totalCount
+        results {
+          fruits (pagination: $pagination) {
+            totalCount
+            results {
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+
+    res = schema.execute_sync(query)
+    assert res.errors is None
+    assert res.data == {
+        "colors": {
+            "totalCount": 2,
+            "results": [
+                {
+                    "fruits": {
+                        "totalCount": 2,
+                        "results": [{"name": "Apple"}, {"name": "Strawberry"}],
+                    }
+                },
+                {
+                    "fruits": {
+                        "totalCount": 1,
+                        "results": [{"name": "Banana"}],
+                    }
+                },
+            ],
+        }
+    }
+
+    res = schema.execute_sync(query, variable_values={"pagination": {"limit": 1}})
+    assert res.errors is None
+    assert res.data == {
+        "colors": {
+            "totalCount": 2,
+            "results": [
+                {
+                    "fruits": {
+                        "totalCount": 2,
+                        "results": [{"name": "Apple"}],
+                    }
+                },
+                {
+                    "fruits": {
+                        "totalCount": 1,
+                        "results": [{"name": "Banana"}],
+                    }
+                },
+            ],
+        }
+    }
+
+    res = schema.execute_sync(
+        query, variable_values={"pagination": {"limit": 1, "offset": 1}}
+    )
+    assert res.errors is None
+    assert res.data == {
+        "colors": {
+            "totalCount": 2,
+            "results": [
+                {
+                    "fruits": {
+                        "totalCount": 2,
+                        "results": [{"name": "Strawberry"}],
+                    }
+                },
+                {
+                    "fruits": {
+                        "totalCount": 1,
+                        "results": [],
+                    }
+                },
+            ],
+        }
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_pagination_nested_query_async():
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry_django.type(models.Color)
+    class Color:
+        id: int
+        name: str
+        fruits: Paginated[Fruit]
+
+    @strawberry.type
+    class Query:
+        colors: Paginated[Color] = strawberry_django.field()
+
+    red = await models.Color.objects.acreate(name="Red")
+    yellow = await models.Color.objects.acreate(name="Yellow")
+
+    await models.Fruit.objects.acreate(name="Apple", color=red)
+    await models.Fruit.objects.acreate(name="Banana", color=yellow)
+    await models.Fruit.objects.acreate(name="Strawberry", color=red)
+
+    schema = strawberry.Schema(query=Query)
+
+    query = """\
+    query GetColors ($pagination: OffsetPaginationInput) {
+      colors {
+        totalCount
+        results {
+          fruits (pagination: $pagination) {
+            totalCount
+            results {
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+
+    res = await schema.execute(query)
+    assert res.errors is None
+    assert res.data == {
+        "colors": {
+            "totalCount": 2,
+            "results": [
+                {
+                    "fruits": {
+                        "totalCount": 2,
+                        "results": [{"name": "Apple"}, {"name": "Strawberry"}],
+                    }
+                },
+                {
+                    "fruits": {
+                        "totalCount": 1,
+                        "results": [{"name": "Banana"}],
+                    }
+                },
+            ],
+        }
+    }
+
+    res = await schema.execute(query, variable_values={"pagination": {"limit": 1}})
+    assert res.errors is None
+    assert res.data == {
+        "colors": {
+            "totalCount": 2,
+            "results": [
+                {
+                    "fruits": {
+                        "totalCount": 2,
+                        "results": [{"name": "Apple"}],
+                    }
+                },
+                {
+                    "fruits": {
+                        "totalCount": 1,
+                        "results": [{"name": "Banana"}],
+                    }
+                },
+            ],
+        }
+    }
+
+    res = await schema.execute(
+        query, variable_values={"pagination": {"limit": 1, "offset": 1}}
+    )
+    assert res.errors is None
+    assert res.data == {
+        "colors": {
+            "totalCount": 2,
+            "results": [
+                {
+                    "fruits": {
+                        "totalCount": 2,
+                        "results": [{"name": "Strawberry"}],
+                    }
+                },
+                {
+                    "fruits": {
+                        "totalCount": 1,
+                        "results": [],
+                    }
+                },
+            ],
+        }
+    }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,7 @@ def test_non_defaults():
             MAP_AUTO_ID_AS_GLOBAL_ID=True,
             DEFAULT_PK_FIELD_NAME="id",
             USE_DEPRECATED_FILTERS=True,
+            PAGINATION_DEFAULT_LIMIT=250,
         ),
     ):
         assert (
@@ -43,5 +44,6 @@ def test_non_defaults():
                 MAP_AUTO_ID_AS_GLOBAL_ID=True,
                 DEFAULT_PK_FIELD_NAME="id",
                 USE_DEPRECATED_FILTERS=True,
+                PAGINATION_DEFAULT_LIMIT=250,
             )
         )


### PR DESCRIPTION
Fix #408

- [x] Create `Paginated` generic type
- [x] Integrate `Paginated` with StrawberryDjangoField
- [x] Ensure it is working with the optimizer
- [x] Ensure it is working with permissions
- [x] Update the documentation

## Summary by Sourcery

Introduce a new Paginated generic type for handling paginated results, integrate it with StrawberryDjangoField, and update documentation and tests to support this new feature.

New Features:
- Introduce a new Paginated generic type to handle paginated results in a more structured way.

Enhancements:
- Integrate the Paginated generic with StrawberryDjangoField to support pagination in GraphQL queries.
- Ensure compatibility of the Paginated generic with existing optimizers and permission systems.

Documentation:
- Update documentation to include usage instructions and examples for the new Paginated generic type.

Tests:
- Add tests to verify the functionality of the Paginated generic type, including its integration with permissions and nested queries.