### PR TITLE
docs: Remove mention about having to enable subscriptions in the docs

### DIFF
--- a/docs/guide/subscriptions.md
+++ b/docs/guide/subscriptions.md
@@ -45,27 +45,7 @@ application = AuthGraphQLProtocolTypeRouter(
 )
 ```
 
-Also, ensure that you enable subscriptions on your AsgiGraphQLView in `MyProject.urls.py`:
-
-```python
-...
-
-urlpatterns = [
-	...
-    path(
-        'graphql/',
-        AsyncGraphQLView.as_view(
-            schema=schema,
-            graphiql=settings.DEBUG,
-            subscriptions_enabled=True,
-        ),
-    ),
-    ...
-]
-
-```
-
-Note, django-channels allows for a lot more complexity. Here we merely cover the basic framework to get subscriptions to run on Django with minimal effort. Should you be interested in discovering the far more advanced capabilities of Dango channels, head over to [channels docs](https://channels.readthedocs.io)
+Note, django-channels allows for a lot more complexity. Here we merely cover the basic framework to get subscriptions to run on Django with minimal effort. Should you be interested in discovering the far more advanced capabilities of Django channels, head over to [channels docs](https://channels.readthedocs.io)
 
 ## Setup local testing
 


### PR DESCRIPTION
The subscriptions feature is now enabled by default.

Not only that, but the keyword to enable it got removed in https://github.com/strawberry-graphql/strawberry/releases/tag/0.245.0

Fix #644

## Summary by Sourcery

Documentation:
- Remove outdated instructions for enabling subscriptions in the documentation.