### PR TITLE
fix: Make sure that async fields always return Awaitables

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -28,6 +28,7 @@ from strawberry import UNSET, relay
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.types.fields.resolver import StrawberryResolver
 from strawberry.types.info import Info  # noqa: TCH002
+from strawberry.utils.await_maybe import await_maybe
 
 from strawberry_django import optimizer
 from strawberry_django.arguments import argument
@@ -215,10 +216,10 @@ class StrawberryDjangoField(
                 if isinstance(attr, FileDescriptor) and not result:
                     result = None
 
-        if is_awaitable:
+        if is_awaitable or self.is_async:
 
             async def async_resolver():
-                resolved = await result  # type: ignore
+                resolved = await await_maybe(result)
 
                 if isinstance(resolved, BaseManager):
                     resolved = resolve_base_manager(resolved)

--- a/tests/test_field_permissions.py
+++ b/tests/test_field_permissions.py
@@ -1,0 +1,272 @@
+from collections.abc import Awaitable
+from typing import Any, Union
+
+import pytest
+import strawberry
+from strawberry import BasePermission, Info
+
+import strawberry_django
+from strawberry_django.optimizer import DjangoOptimizerExtension
+from tests import models
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_with_async_permission(db):
+    class AsyncPermission(BasePermission):
+        async def has_permission(  # type: ignore
+            self,
+            source: Any,
+            info: Info,
+            **kwargs: Any,
+        ) -> Union[bool, Awaitable[bool]]:
+            return True
+
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        name: strawberry.auto
+
+    @strawberry_django.type(models.Color)
+    class Color:
+        name: strawberry.auto
+        fruits: list[Fruit] = strawberry_django.field(
+            permission_classes=[AsyncPermission]
+        )
+
+    @strawberry.type(name="Query")
+    class Query:
+        colors: list[Color] = strawberry_django.field()
+
+    red = await models.Color.objects.acreate(name="Red")
+    yellow = await models.Color.objects.acreate(name="Yellow")
+
+    await models.Fruit.objects.acreate(name="Apple", color=red)
+    await models.Fruit.objects.acreate(name="Banana", color=yellow)
+    await models.Fruit.objects.acreate(name="Strawberry", color=red)
+
+    schema = strawberry.Schema(query=Query)
+    query = """
+        query {
+          colors {
+            name
+            fruits {
+              name
+            }
+          }
+        }
+    """
+
+    result = await schema.execute(query)
+    assert result.errors is None
+    assert result.data == {
+        "colors": [
+            {
+                "name": "Red",
+                "fruits": [
+                    {"name": "Apple"},
+                    {"name": "Strawberry"},
+                ],
+            },
+            {
+                "name": "Yellow",
+                "fruits": [{"name": "Banana"}],
+            },
+        ]
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_with_async_permission_and_optimizer(db):
+    class AsyncPermission(BasePermission):
+        async def has_permission(  # type: ignore
+            self,
+            source: Any,
+            info: Info,
+            **kwargs: Any,
+        ) -> Union[bool, Awaitable[bool]]:
+            return True
+
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        name: strawberry.auto
+
+    @strawberry_django.type(models.Color)
+    class Color:
+        name: strawberry.auto
+        fruits: list[Fruit] = strawberry_django.field(
+            permission_classes=[AsyncPermission]
+        )
+
+    @strawberry.type(name="Query")
+    class Query:
+        colors: list[Color] = strawberry_django.field()
+
+    red = await models.Color.objects.acreate(name="Red")
+    yellow = await models.Color.objects.acreate(name="Yellow")
+
+    await models.Fruit.objects.acreate(name="Apple", color=red)
+    await models.Fruit.objects.acreate(name="Banana", color=yellow)
+    await models.Fruit.objects.acreate(name="Strawberry", color=red)
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[DjangoOptimizerExtension()],
+    )
+    query = """
+        query {
+          colors {
+            name
+            fruits {
+              name
+            }
+          }
+        }
+    """
+
+    result = await schema.execute(query)
+    assert result.errors is None
+    assert result.data == {
+        "colors": [
+            {
+                "name": "Red",
+                "fruits": [
+                    {"name": "Apple"},
+                    {"name": "Strawberry"},
+                ],
+            },
+            {
+                "name": "Yellow",
+                "fruits": [{"name": "Banana"}],
+            },
+        ]
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_with_sync_permission(db):
+    class AsyncPermission(BasePermission):
+        def has_permission(
+            self,
+            source: Any,
+            info: Info,
+            **kwargs: Any,
+        ) -> Union[bool, Awaitable[bool]]:
+            return True
+
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        name: strawberry.auto
+
+    @strawberry_django.type(models.Color)
+    class Color:
+        name: strawberry.auto
+        fruits: list[Fruit] = strawberry_django.field(
+            permission_classes=[AsyncPermission]
+        )
+
+    @strawberry.type(name="Query")
+    class Query:
+        colors: list[Color] = strawberry_django.field()
+
+    red = models.Color.objects.create(name="Red")
+    yellow = models.Color.objects.create(name="Yellow")
+
+    models.Fruit.objects.create(name="Apple", color=red)
+    models.Fruit.objects.create(name="Banana", color=yellow)
+    models.Fruit.objects.create(name="Strawberry", color=red)
+
+    schema = strawberry.Schema(query=Query)
+    query = """
+        query {
+          colors {
+            name
+            fruits {
+              name
+            }
+          }
+        }
+    """
+
+    result = schema.execute_sync(query)
+    assert result.errors is None
+    assert result.data == {
+        "colors": [
+            {
+                "name": "Red",
+                "fruits": [
+                    {"name": "Apple"},
+                    {"name": "Strawberry"},
+                ],
+            },
+            {
+                "name": "Yellow",
+                "fruits": [{"name": "Banana"}],
+            },
+        ]
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_with_sync_permission_and_optimizer(db):
+    class AsyncPermission(BasePermission):
+        def has_permission(
+            self,
+            source: Any,
+            info: Info,
+            **kwargs: Any,
+        ) -> Union[bool, Awaitable[bool]]:
+            return True
+
+    @strawberry_django.type(models.Fruit)
+    class Fruit:
+        name: strawberry.auto
+
+    @strawberry_django.type(models.Color)
+    class Color:
+        name: strawberry.auto
+        fruits: list[Fruit] = strawberry_django.field(
+            permission_classes=[AsyncPermission]
+        )
+
+    @strawberry.type(name="Query")
+    class Query:
+        colors: list[Color] = strawberry_django.field()
+
+    red = models.Color.objects.create(name="Red")
+    yellow = models.Color.objects.create(name="Yellow")
+
+    models.Fruit.objects.create(name="Apple", color=red)
+    models.Fruit.objects.create(name="Banana", color=yellow)
+    models.Fruit.objects.create(name="Strawberry", color=red)
+
+    schema = strawberry.Schema(
+        query=Query,
+        extensions=[DjangoOptimizerExtension()],
+    )
+    query = """
+        query {
+          colors {
+            name
+            fruits {
+              name
+            }
+          }
+        }
+    """
+
+    result = schema.execute_sync(query)
+    assert result.errors is None
+    assert result.data == {
+        "colors": [
+            {
+                "name": "Red",
+                "fruits": [
+                    {"name": "Apple"},
+                    {"name": "Strawberry"},
+                ],
+            },
+            {
+                "name": "Yellow",
+                "fruits": [{"name": "Banana"}],
+            },
+        ]
+    }


### PR DESCRIPTION
Async fields sometimes can return non-awaitable values, like when the optimizer is enabled and already prefetched the nested field.

This can break some places that expect an awaitable, like strawberry's base field permissions.

This change ensures that async fields always return an awaitable.

Fix #639

## Summary by Sourcery

Fix async fields to consistently return awaitables, addressing issues with components expecting awaitable results, and add tests to validate this behavior.

Bug Fixes:
- Ensure async fields always return an awaitable to prevent issues with components expecting awaitable results.

Tests:
- Add tests to verify async field permissions and behavior with and without optimizers, ensuring consistent awaitable returns.