### PR TITLE
update model_property path in the doc

### DIFF
--- a/docs/guide/optimizer.md
+++ b/docs/guide/optimizer.md
@@ -269,7 +269,7 @@ For that this integration provides 2 decorators that can be used:
 The example in the previous section could be written using `@model_property` like this:
 
 ```python title="models.py"
-from strawberry_django import model_property
+from strawberry_django.descriptors import model_property
 
 class OrderItem(models.Model):
     price = models.DecimalField()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The `model_property` path in the doc is wrong. It should be 
```py
from strawberry_django.descriptors import model_property
```

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Documentation:
- Correct the import path for `model_property` in the documentation to `from strawberry_django.descriptors import model_property`.