### PR TITLE
Support multi-level nested create/update with model `full_clean()`

### DIFF
--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -334,7 +334,6 @@ def create(
 ) -> list[_M]: ...
 
 
-@transaction.atomic
 def create(
     info: Info,
     model: type[_M],

--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -14,7 +14,6 @@ from typing import (
 
 import strawberry
 from django.db import models, transaction
-from django.db.models.manager import BaseManager
 from django.db.models.base import Model
 from django.db.models.fields.related import ManyToManyField
 from django.db.models.fields.reverse_related import (
@@ -45,7 +44,11 @@ from .types import (
 )
 
 if TYPE_CHECKING:
-    from django.db.models.manager import ManyToManyRelatedManager, RelatedManager
+    from django.db.models.manager import (
+        BaseManager,
+        ManyToManyRelatedManager,
+        RelatedManager,
+    )
     from strawberry.types.info import Info
 
 

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -358,6 +358,7 @@ class MilestoneInput:
 class MilestoneInputPartial(NodeInputPartial):
     name: strawberry.auto
     issues: Optional[list[MilestoneIssueInputPartial]]
+    project: Optional[ProjectInputPartial]
 
 
 @strawberry.type

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -338,6 +338,7 @@ class MilestoneIssueInput:
 @strawberry_django.partial(Issue)
 class MilestoneIssueInputPartial:
     name: strawberry.auto
+    tags: Optional[list[TagInputPartial]]
 
 
 @strawberry_django.partial(Project)

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -526,6 +526,11 @@ class Mutation:
         argument_name="input",
         key_attr="name",
     )
+    create_project_with_milestones: ProjectType = mutations.create(
+        ProjectInputPartial,
+        handle_django_errors=True,
+        argument_name="input",
+    )
     update_project: ProjectType = mutations.update(
         ProjectInputPartial,
         handle_django_errors=True,

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -335,6 +335,11 @@ class MilestoneIssueInput:
     name: strawberry.auto
 
 
+@strawberry_django.partial(Issue)
+class MilestoneIssueInputPartial:
+    name: strawberry.auto
+
+
 @strawberry_django.partial(Project)
 class ProjectInputPartial(NodeInputPartial):
     name: strawberry.auto
@@ -351,6 +356,7 @@ class MilestoneInput:
 @strawberry_django.partial(Milestone)
 class MilestoneInputPartial(NodeInputPartial):
     name: strawberry.auto
+    issues: Optional[list[MilestoneIssueInputPartial]]
 
 
 @strawberry.type

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -368,6 +368,7 @@ input MilestoneInputPartial {
   id: GlobalID
   name: String
   issues: [MilestoneIssueInputPartial!]
+  project: ProjectInputPartial
 }
 
 input MilestoneIssueInput {

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -95,6 +95,8 @@ input CreateProjectInput {
 
 union CreateProjectPayload = ProjectType | OperationInfo
 
+union CreateProjectWithMilestonesPayload = ProjectType | OperationInfo
+
 input CreateQuizInput {
   title: String!
   fullCleanOptions: Boolean! = false
@@ -437,6 +439,7 @@ type Mutation {
   updateIssueWithKeyAttr(input: IssueInputPartialWithoutId!): UpdateIssueWithKeyAttrPayload!
   deleteIssue(input: NodeInput!): DeleteIssuePayload!
   deleteIssueWithKeyAttr(input: MilestoneIssueInput!): DeleteIssueWithKeyAttrPayload!
+  createProjectWithMilestones(input: ProjectInputPartial!): CreateProjectWithMilestonesPayload!
   updateProject(input: ProjectInputPartial!): UpdateProjectPayload!
   createMilestone(input: MilestoneInput!): CreateMilestonePayload!
   createProject(

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -365,10 +365,15 @@ input MilestoneInput {
 input MilestoneInputPartial {
   id: GlobalID
   name: String
+  issues: [MilestoneIssueInputPartial!]
 }
 
 input MilestoneIssueInput {
   name: String!
+}
+
+input MilestoneIssueInputPartial {
+  name: String
 }
 
 input MilestoneOrder {

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -374,6 +374,7 @@ input MilestoneIssueInput {
 
 input MilestoneIssueInputPartial {
   name: String
+  tags: [TagInputPartial!]
 }
 
 input MilestoneOrder {

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -164,6 +164,7 @@ input MilestoneInputPartial {
 
 input MilestoneIssueInputPartial {
   name: String
+  tags: [TagInputPartial!]
 }
 
 input MilestoneOrder {
@@ -404,6 +405,11 @@ input StrFilterLookup {
   Case-insensitive regular expression match. Filter will be skipped on `null` value
   """
   iRegex: String
+}
+
+input TagInputPartial {
+  id: GlobalID
+  name: String
 }
 
 type TagType implements Node & Named {

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -160,6 +160,7 @@ input MilestoneInputPartial {
   id: GlobalID
   name: String
   issues: [MilestoneIssueInputPartial!]
+  project: ProjectInputPartial
 }
 
 input MilestoneIssueInputPartial {
@@ -308,6 +309,12 @@ type PageInfo {
 
   """When paginating forwards, the cursor to continue."""
   endCursor: String
+}
+
+input ProjectInputPartial {
+  id: GlobalID
+  name: String
+  milestones: [MilestoneInputPartial!]
 }
 
 input ProjectOrder {

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -159,6 +159,11 @@ input MilestoneFilter {
 input MilestoneInputPartial {
   id: GlobalID
   name: String
+  issues: [MilestoneIssueInputPartial!]
+}
+
+input MilestoneIssueInputPartial {
+  name: String
 }
 
 input MilestoneOrder {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

This implements the core functionality of #604, allowing multi-level create/update of nested resources. It also ensures that `model.full_clean()` is called before creating a new resource, which ensures that internal information about constraint names doesn't leak out to the client via `IntegrityError` messages (see #398).

To solve this, we allow `update_m2m` to recursively call `create()`, ensuring that the logic for creation of records uses a consistent code path regardless of what depth in the nested data it is created at.

### Notes

This is not everything from #604, nor does it fix all of #603. It does fix all of #398. It seemed like #604 was getting too large to review though, so I'm hoping this approach of breaking it up into smaller chunks will work better.

Part of the reason why this approach was a bit easier was that I didn't try to preserve the change from #362. This change didn't come with any tests, has probably been superseded by the `key_attr` functionality that was added after the fix was merged, and it seems risky to assume that the default behaviour should be to reuse an existing model instance just because some fields match (as pointed out by @bellini666 previously in [this](https://github.com/strawberry-graphql/strawberry-django/pull/604#discussion_r1703176752) comment).

From the changes in this PR, I see several other subsequent bugfixes/improvements that could be made to address the remaining issues from #603 and comments raised in the previous PR #604:

- nested creation of OneToOne fields (#603)
- Allow `key_attr` to specify more than one column to perform the lookup on (comment in #604)
- Allow `key_attr` and full_clean/full_clean_options to be specified individually for each type(?) of nested resource specified.
- Validation field names should be prefixed with the field name of the nested resource. The format `project.milestones.0.name` or `project.milestones.0.issues.2.tags.3.name` could be an option?. Validation errors probably shouldn't stop other nested resources from being created, so all validation errors can be caught and returned at the end. (#404)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #398
* Some of #603

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Implement support for multi-level nested create and update operations with model full_clean() to enhance data integrity and prevent constraint name leaks. Add tests to verify the new functionality.

New Features:
- Implement multi-level nested create and update functionality for resources, allowing recursive calls to create nested resources.

Bug Fixes:
- Fix issue #398 by ensuring model.full_clean() is called before creating a new resource to prevent leaking internal constraint names via IntegrityError messages.

Enhancements:
- Add support for excluding certain many-to-many fields from processing during create and update operations to prevent circular references.

Tests:
- Add tests for multi-level nested creation and update mutations to ensure the new functionality works as expected.