### PR TITLE
Fix Django permissions diagram syntax

### DIFF
--- a/docs/guide/permissions.md
+++ b/docs/guide/permissions.md
@@ -30,7 +30,7 @@ graph TD
   D -->|No| E;
   E[Field is a 'List'] -->|Yes| EF[Return an empty 'List'];
   E -->|No| F;
-  F[Field is a relay `Connection`] -->|Yes| FF[Return an empty relay 'Connection'];
+  F[Field is a relay 'Connection'] -->|Yes| FF[Return an empty relay 'Connection'];
   F -->|No| GF[Raises 'PermissionDenied' error];
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

The [Django permissions docs](https://strawberry.rocks/docs/django/guide/permissions) have a syntax error which breaks the diagram slightly:

![image](https://github.com/user-attachments/assets/c2f22bf1-8702-4849-92d5-3ebecaa63049)

so, we take the same approach as the "Return an empty relay 'Connection'" box just below and simply remove the unsupported syntax.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Documentation:
- Correct the syntax error in the Django permissions diagram by removing unsupported syntax.