### PR TITLE
Forward metadata when processing django type

### DIFF
--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -367,6 +367,7 @@ def _process_type(
                 permission_classes=getattr(f, "permission_classes", ()),
                 default=getattr(f, "default", dataclasses.MISSING),
                 default_factory=getattr(f, "default_factory", dataclasses.MISSING),
+                metadata=getattr(f, "metadata", None),
                 deprecation_reason=getattr(f, "deprecation_reason", None),
                 directives=getattr(f, "directives", ()),
                 pagination=getattr(f, "pagination", UNSET),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

When trying to allow None filtering on a nullable FK, I found that metadata attr, where this info is stored, was not transferred to the underlying StrawberryField. So I fixed that.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix the issue where metadata attributes were not being forwarded to the underlying StrawberryField when processing Django types, and add a test to ensure filtering on nullable foreign keys with None values works correctly.

Bug Fixes:
- Fix metadata attribute not being transferred to the underlying StrawberryField when processing Django types.

Tests:
- Add a test to verify filtering on nullable foreign keys with None values.