### PR TITLE
allow FullCleanOptions in full_clean arg annotation

### DIFF
--- a/strawberry_django/mutations/fields.py
+++ b/strawberry_django/mutations/fields.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
     )
     from typing_extensions import Literal, Self
 
+    from .types import FullCleanOptions
+
 
 def _get_validation_errors(error: Exception):
     if isinstance(error, PermissionDenied):
@@ -177,7 +179,7 @@ class DjangoMutationCUD(DjangoMutationBase):
     def __init__(
         self,
         input_type: type | None = None,
-        full_clean: bool = True,
+        full_clean: bool | FullCleanOptions = True,
         argument_name: str | None = None,
         key_attr: str | None = None,
         **kwargs,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Fix the type annotation for the 'full_clean' argument in the DjangoMutationCUD class to accept both boolean and FullCleanOptions types.