### PR TITLE
Added missing unpacking of strawberry.LazyType to optimzer.py

### DIFF
--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -1193,6 +1193,10 @@ def _get_model_hints_from_paginated(
     store = None
 
     n_type = object_definition.type_var_map.get("NodeType")
+
+    if isinstance(n_type, LazyType):
+        n_type = n_type.resolve_type()
+
     n_definition = get_object_definition(n_type, strict=True)
     n_gql_definition = _get_gql_definition(
         schema,


### PR DESCRIPTION
The query optimizer doesn't properly unpack LazyType on PaginatedRespone handling.
This fixes it the same way _get_model_hints_from_connection does it.

## Types of Changes

- [ ] Core
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
