### PR TITLE
fix(pagination)!: Use `PAGINATION_DEFAULT_LIMIT` when limit is not provided

### DIFF
--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -13,9 +13,9 @@ from typing_extensions import Self
 
 from strawberry_django.fields.base import StrawberryDjangoFieldBase
 from strawberry_django.resolvers import django_resolver
-from .settings import strawberry_django_settings
 
 from .arguments import argument
+from .settings import strawberry_django_settings
 
 NodeType = TypeVar("NodeType")
 _QS = TypeVar("_QS", bound=QuerySet)

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -470,7 +470,7 @@ type OffsetPaginationInfo {
 
 input OffsetPaginationInput {
   offset: Int! = 0
-  limit: Int = null
+  limit: Int
 }
 
 type OperationInfo {

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -248,7 +248,7 @@ type OffsetPaginationInfo {
 
 input OffsetPaginationInput {
   offset: Int! = 0
-  limit: Int = null
+  limit: Int
 }
 
 type OperationInfo {

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -1,10 +1,10 @@
 import textwrap
 from typing import Annotated
 
-from django.test.utils import override_settings
 import pytest
 import strawberry
 from django.db.models import QuerySet
+from django.test.utils import override_settings
 
 import strawberry_django
 from strawberry_django.optimizer import DjangoOptimizerExtension


### PR DESCRIPTION
An oversight from my side when working on https://github.com/strawberry-graphql/strawberry-django/pull/642

Fix https://github.com/strawberry-graphql/strawberry-django/issues/656

## Summary by Sourcery

Fix the pagination logic to use the `PAGINATION_DEFAULT_LIMIT` setting when the limit is not explicitly provided in the pagination input. Update the pagination input and info classes to handle unset limits correctly and add tests to ensure the default limit is applied as expected.

Bug Fixes:
- Ensure the default pagination limit is applied when the limit is not provided in the pagination input.

Tests:
- Add a test to verify that the default pagination limit is used when no limit is specified in the query.