### PR TITLE
fix(mutations): Refetch instances to optimize the return value

### DIFF
--- a/tests/test_input_mutations.py
+++ b/tests/test_input_mutations.py
@@ -541,6 +541,7 @@ def test_input_update_m2m_set_not_null_mutation(db, gql_client: GraphQLTestClien
           id
           name
           dueDate
+          isDelayed
           milestones {
             id
             name
@@ -557,15 +558,17 @@ def test_input_update_m2m_set_not_null_mutation(db, gql_client: GraphQLTestClien
     milestone_1_id = to_base64("MilestoneType", milestone_1.pk)
     MilestoneFactory.create(project=project)
 
-    res = gql_client.query(
-        query,
-        {
-            "input": {
-                "id": to_base64("ProjectType", project.pk),
-                "milestones": [{"id": milestone_1_id}],
+    with assert_num_queries(14):
+        res = gql_client.query(
+            query,
+            {
+                "input": {
+                    "id": to_base64("ProjectType", project.pk),
+                    "milestones": [{"id": milestone_1_id}],
+                },
             },
-        },
-    )
+        )
+
     assert res.data
     assert isinstance(res.data["updateProject"], dict)
 


### PR DESCRIPTION
Refetch instances after the mutation to make sure we optimize the result.

Without this, `annotated` fields would not exist in the return value and would fail to be returned.

I'm also modifying a test to include an annotated field. Without this change applied it would fail.

Fix https://github.com/strawberry-graphql/strawberry-django/issues/635

## Summary by Sourcery

Refetch instances after mutations to ensure annotated fields are included in the return value, addressing issue #635. Introduce a refetch method to optimize the retrieval of instances post-mutation. Add a test case to verify the inclusion of the 'isDelayed' field in the mutation response.

Bug Fixes:
- Refetch instances after mutations to ensure annotated fields are included in the return value, addressing issue #635.

Enhancements:
- Introduce a refetch method to optimize the retrieval of instances post-mutation.

Tests:
- Add a test case to verify the inclusion of the 'isDelayed' field in the mutation response.