### PR TITLE
fix: skip empty choice value

### DIFF
--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -466,7 +466,11 @@ def resolve_model_field_type(
             meta = model_field.model._meta
 
             enum_choices = {}
-            for c in cast("Iterable[tuple[str, str]]", model_field.choices):
+            for c in cast("Iterable[tuple[str | None, str]]", model_field.choices):
+                # Skip empty choice (__empty__)
+                if not c[0]:
+                    continue
+
                 # replace chars not compatible with GraphQL naming convention
                 choice_name = re.sub(r"^[^_a-zA-Z]|[^_a-zA-Z0-9]", "_", c[0])
                 # use str() to trigger eventual django's gettext_lazy string

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -24,6 +24,7 @@ class Choice(models.TextChoices):
     C = "c", gettext_lazy("C description")
     D = "12d-d'éléphant_🐘", "D description"
     E = "_2d_d__l_phant__", "E description"
+    __empty__ = "Empty"
 
 
 class IntegerChoice(models.IntegerChoices):


### PR DESCRIPTION
Seems they are not supported by GraphQL

Having an empty choice make generate enum from choice feature crash, trying to use None as a string.

```
class Choice(models.TextChoices):
    A = "a", "A description"
    B = "b", "B description"
    __empty__ =  "Empty"
```
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The fix, for now, is to skip empty value, so the behavior is the same as `TextChoiceField`. 
It make the schema building pass, but sadly, data with an empty value will still fail with `Enum 'MyAutoGeneratedEnum' cannot represent value: ''` and I'm note sure what to do with that.



## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when generating enums from choices with empty values by skipping them.