### PR TITLE
feat: omit TestClient from pytest's test discovery

### DIFF
--- a/strawberry_django/test/client.py
+++ b/strawberry_django/test/client.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 
 class TestClient(BaseGraphQLTestClient):
+    __test__ = False
+
     def __init__(self, path: str, client: Optional[Client] = None):
         self.path = path
         super().__init__(client or Client())


### PR DESCRIPTION
## Description

`pytest`'s test discovery treats the `strawberry_django.test.client.TestClient` class as a test class, and raises a warning similar to:

```
/app/.venv/lib/python3.13/site-packages/strawberry_django/test/client.py:16:
    PytestCollectionWarning: cannot collect test class 'TestClient' because it has a __init__ constructor
```

This PR adds the attribute `__test__ = False`, which prevents test discovery within the class, and suppresses the warning.

### Source

- https://docs.pytest.org/en/stable/example/pythoncollection.html#customizing-test-collection

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Enhancements:
- Prevent pytest from treating TestClient as a test class by setting __test__ = False.