### PR TITLE
Order unordered querysets by primary key

### DIFF
--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -436,6 +436,16 @@ type MilestoneTypeEdge {
   node: MilestoneType!
 }
 
+type MilestoneTypeOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
+
+  """Total count of existing results."""
+  totalCount: Int!
+
+  """List of paginated results."""
+  results: [MilestoneType!]!
+}
+
 type Mutation {
   createIssue(input: IssueInput!): CreateIssuePayload!
   updateIssue(input: IssueInputPartial!): UpdateIssuePayload!
@@ -574,11 +584,30 @@ type ProjectType implements Node & Named {
   id: GlobalID!
   name: String!
   dueDate: Date
-  milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
-  milestonesCount: Int!
+  isSmall: Boolean!
   isDelayed: Boolean!
   cost: Decimal @isAuthenticated
-  isSmall: Boolean!
+  milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
+  milestonesCount: Int!
+  firstMilestone: MilestoneType
+  firstMilestoneRequired: MilestoneType!
+  milestoneConn(
+    filters: MilestoneFilter
+    order: MilestoneOrder
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MilestoneTypeConnection!
+  milestonesPaginated(pagination: OffsetPaginationInput, filters: MilestoneFilter, order: MilestoneOrder): MilestoneTypeOffsetPaginated!
 }
 
 """An edge in a connection."""
@@ -588,6 +617,16 @@ type ProjectTypeEdge {
 
   """The item at the end of the edge"""
   node: ProjectType!
+}
+
+type ProjectTypeOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
+
+  """Total count of existing results."""
+  totalCount: Int!
+
+  """List of paginated results."""
+  results: [ProjectType!]!
 }
 
 type Query {
@@ -621,6 +660,10 @@ type Query {
     """The ID of the object."""
     id: GlobalID!
   ): ProjectType
+  projectMandatory(
+    """The ID of the object."""
+    id: GlobalID!
+  ): ProjectType!
   projectLoginRequired(
     """The ID of the object."""
     id: GlobalID!
@@ -641,6 +684,7 @@ type Query {
   issuesPaginated(pagination: OffsetPaginationInput): IssueTypeOffsetPaginated!
   milestoneList(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
   projectList(filters: ProjectFilter): [ProjectType!]!
+  projectsPaginated(pagination: OffsetPaginationInput, filters: ProjectFilter): ProjectTypeOffsetPaginated!
   tagList: [TagType!]!
   favoriteConn(
     """Returns the items in the list that come before the specified cursor."""

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -203,6 +203,37 @@ type MilestoneType implements Node & Named {
   asyncField(value: String!): String!
 }
 
+"""A connection to a list of items."""
+type MilestoneTypeConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [MilestoneTypeEdge!]!
+
+  """Total quantity of existing nodes."""
+  totalCount: Int
+}
+
+"""An edge in a connection."""
+type MilestoneTypeEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: MilestoneType!
+}
+
+type MilestoneTypeOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
+
+  """Total count of existing results."""
+  totalCount: Int!
+
+  """List of paginated results."""
+  results: [MilestoneType!]!
+}
+
 type MilestoneTypeSubclass implements Node & Named {
   """The Globally Unique ID of this object"""
   id: GlobalID!
@@ -331,11 +362,30 @@ type ProjectType implements Node & Named {
   id: GlobalID!
   name: String!
   dueDate: Date
-  milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
-  milestonesCount: Int!
+  isSmall: Boolean!
   isDelayed: Boolean!
   cost: Decimal @isAuthenticated
-  isSmall: Boolean!
+  milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
+  milestonesCount: Int!
+  firstMilestone: MilestoneType
+  firstMilestoneRequired: MilestoneType!
+  milestoneConn(
+    filters: MilestoneFilter
+    order: MilestoneOrder
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MilestoneTypeConnection!
+  milestonesPaginated(pagination: OffsetPaginationInput, filters: MilestoneFilter, order: MilestoneOrder): MilestoneTypeOffsetPaginated!
 }
 
 type ProjectTypeSubclass implements Node & Named {
@@ -343,11 +393,30 @@ type ProjectTypeSubclass implements Node & Named {
   id: GlobalID!
   name: String!
   dueDate: Date
-  milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
-  milestonesCount: Int!
+  isSmall: Boolean!
   isDelayed: Boolean!
   cost: Decimal @isAuthenticated
-  isSmall: Boolean!
+  milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
+  milestonesCount: Int!
+  firstMilestone: MilestoneType
+  firstMilestoneRequired: MilestoneType!
+  milestoneConn(
+    filters: MilestoneFilter
+    order: MilestoneOrder
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): MilestoneTypeConnection!
+  milestonesPaginated(pagination: OffsetPaginationInput, filters: MilestoneFilter, order: MilestoneOrder): MilestoneTypeOffsetPaginated!
 }
 
 type Query {

--- a/tests/test_deterministic_ordering.py
+++ b/tests/test_deterministic_ordering.py
@@ -1,4 +1,3 @@
-
 import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
@@ -137,7 +136,8 @@ def test_list(gql_client: utils.GraphQLTestClient):
                 "name": project.name,
                 "milestones": [
                     {"name": milestone.name}
-                    for milestone in project.milestones.order_by("pk")],
+                    for milestone in project.milestones.order_by("pk")
+                ],
             }
             for project in Project.objects.order_by("pk")
         ]

--- a/tests/test_deterministic_ordering.py
+++ b/tests/test_deterministic_ordering.py
@@ -2,6 +2,7 @@
 import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from strawberry.relay.utils import to_base64
 
 from tests import utils
 from tests.projects.faker import MilestoneFactory, ProjectFactory
@@ -10,16 +11,92 @@ from tests.projects.models import Milestone, Project
 
 @pytest.mark.django_db(transaction=True)
 def test_required(gql_client: utils.GraphQLTestClient):
-    # TODO: Query a required field, and a nested required field with no ordering
+    # Query a required field, and a nested required field with no ordering
     # We expect the queries to **not** have an `ORDER BY` clause
-    pass
+    query = """
+      query testRequired($id: GlobalID!) {
+        projectMandatory(id: $id) {
+          name
+          firstMilestoneRequired {
+            name
+          }
+        }
+      }
+    """
+
+    # Sanity check the models
+    assert Project._meta.ordering == []
+    assert Milestone._meta.ordering == []
+
+    # Create a project and a milestone
+    project = ProjectFactory()
+    milestone = MilestoneFactory(project=project)
+
+    # Run the query
+    # Capture the SQL queries that are executed
+    with CaptureQueriesContext(connection) as ctx:
+        result = gql_client.query(
+            query,
+            variables={"id": to_base64("ProjectType", project.pk)},
+        )
+
+    # Sanity check the results
+    assert not result.errors
+    assert result.data == {
+        "projectMandatory": {
+            "name": project.name,
+            "firstMilestoneRequired": {"name": milestone.name},
+        }
+    }
+
+    # Assert that the queries do **not** have an `ORDER BY` clause
+    for query in ctx.captured_queries:
+        assert "ORDER BY" not in query["sql"]
 
 
 @pytest.mark.django_db(transaction=True)
 def test_optional(gql_client: utils.GraphQLTestClient):
-    # TODO: Query an optional field, and a nested optional field with no ordering
+    # Query an optional field, and a nested optional field with no ordering
     # We expect the queries to have an `ORDER BY` clause
-    pass
+    query = """
+      query testOptional($id: GlobalID!) {
+        project(id: $id) {
+          name
+          firstMilestone {
+            name
+          }
+        }
+      }
+    """
+
+    # Sanity check the models
+    assert Project._meta.ordering == []
+    assert Milestone._meta.ordering == []
+
+    # Create a project and a milestone
+    project = ProjectFactory()
+    milestone = MilestoneFactory(project=project)
+
+    # Run the query
+    # Capture the SQL queries that are executed
+    with CaptureQueriesContext(connection) as ctx:
+        result = gql_client.query(
+            query,
+            variables={"id": to_base64("ProjectType", project.pk)},
+        )
+
+    # Sanity check the results
+    assert not result.errors
+    assert result.data == {
+        "project": {
+            "name": project.name,
+            "firstMilestone": {"name": milestone.name},
+        }
+    }
+
+    # Assert that the queries do have an `ORDER BY` clause
+    for query in ctx.captured_queries:
+        assert "ORDER BY" in query["sql"]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -27,7 +104,7 @@ def test_list(gql_client: utils.GraphQLTestClient):
     # Query a list field, and a nested list field with no ordering
     # We expect the queries to have an `ORDER BY` clause
     query = """
-      query {
+      query testList{
         projectList {
           name
           milestones {
@@ -66,22 +143,128 @@ def test_list(gql_client: utils.GraphQLTestClient):
         ]
     }
 
-    # This is a bit crude, but all queries should have an `ORDER BY` clause
-    # This can only be true if we are handling this correctly, as the models don't
-    # have any `Meta.ordering` defined
+    # Assert that the queries do have an `ORDER BY` clause
     for query in ctx.captured_queries:
         assert "ORDER BY" in query["sql"]
 
 
 @pytest.mark.django_db(transaction=True)
 def test_connection(gql_client: utils.GraphQLTestClient):
-    # TODO: Query a connection field, and a nested connection field with no ordering
+    # Query a connection field, and a nested connection field with no ordering
     # We expect the queries to have an `ORDER BY` clause
-    pass
+    query = """
+      query testConnection{
+        projectConn {
+          edges {
+            node {
+              name
+              milestoneConn {
+                edges {
+                  node {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    # Sanity check the models
+    assert Project._meta.ordering == []
+    assert Milestone._meta.ordering == []
+
+    # Create some projects and milestones
+    projects = ProjectFactory.create_batch(3)
+    milestones = []
+    for project in projects:
+        milestones.extend(MilestoneFactory.create_batch(3, project=project))
+
+    # Run the query
+    # Capture the SQL queries that are executed
+    with CaptureQueriesContext(connection) as ctx:
+        result = gql_client.query(query)
+
+    # Sanity check the results
+    assert not result.errors
+    assert result.data == {
+        "projectConn": {
+            "edges": [
+                {
+                    "node": {
+                        "name": project.name,
+                        "milestoneConn": {
+                            "edges": [
+                                {"node": {"name": milestone.name}}
+                                for milestone in project.milestones.order_by("pk")
+                            ]
+                        },
+                    }
+                }
+                for project in Project.objects.order_by("pk")
+            ]
+        }
+    }
+
+    # Assert that the queries do have an `ORDER BY` clause
+    for query in ctx.captured_queries:
+        assert "ORDER BY" in query["sql"]
 
 
 @pytest.mark.django_db(transaction=True)
-def test_paginated():
-    # TODO: Query a paginated field, and a nested paginated field with no ordering
+def test_paginated(gql_client: utils.GraphQLTestClient):
+    # Query a paginated field, and a nested paginated field with no ordering
     # We expect the queries to have an `ORDER BY` clause
-    pass
+    query = """
+      query testPaginated{
+        projectsPaginated {
+          results {
+            name
+            milestonesPaginated {
+              results {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    # Sanity check the models
+    assert Project._meta.ordering == []
+    assert Milestone._meta.ordering == []
+
+    # Create some projects and milestones
+    projects = ProjectFactory.create_batch(3)
+    milestones = []
+    for project in projects:
+        milestones.extend(MilestoneFactory.create_batch(3, project=project))
+
+    # Run the query
+    # Capture the SQL queries that are executed
+    with CaptureQueriesContext(connection) as ctx:
+        result = gql_client.query(query)
+
+    # Sanity check the results
+    assert not result.errors
+    assert result.data == {
+        "projectsPaginated": {
+            "results": [
+                {
+                    "name": project.name,
+                    "milestonesPaginated": {
+                        "results": [
+                            {"name": milestone.name}
+                            for milestone in project.milestones.order_by("pk")
+                        ]
+                    },
+                }
+                for project in Project.objects.order_by("pk")
+            ]
+        }
+    }
+
+    # Assert that the queries do have an `ORDER BY` clause
+    for query in ctx.captured_queries:
+        assert "ORDER BY" in query["sql"]

--- a/tests/test_deterministic_ordering.py
+++ b/tests/test_deterministic_ordering.py
@@ -1,0 +1,87 @@
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from tests import utils
+from tests.projects.faker import MilestoneFactory, ProjectFactory
+from tests.projects.models import Milestone, Project
+
+
+@pytest.mark.django_db(transaction=True)
+def test_required(gql_client: utils.GraphQLTestClient):
+    # TODO: Query a required field, and a nested required field with no ordering
+    # We expect the queries to **not** have an `ORDER BY` clause
+    pass
+
+
+@pytest.mark.django_db(transaction=True)
+def test_optional(gql_client: utils.GraphQLTestClient):
+    # TODO: Query an optional field, and a nested optional field with no ordering
+    # We expect the queries to have an `ORDER BY` clause
+    pass
+
+
+@pytest.mark.django_db(transaction=True)
+def test_list(gql_client: utils.GraphQLTestClient):
+    # Query a list field, and a nested list field with no ordering
+    # We expect the queries to have an `ORDER BY` clause
+    query = """
+      query {
+        projectList {
+          name
+          milestones {
+            name
+          }
+        }
+      }
+    """
+
+    # Sanity check the models
+    assert Project._meta.ordering == []
+    assert Milestone._meta.ordering == []
+
+    # Create some projects and milestones
+    projects = ProjectFactory.create_batch(3)
+    milestones = []
+    for project in projects:
+        milestones.extend(MilestoneFactory.create_batch(3, project=project))
+
+    # Run the query
+    # Capture the SQL queries that are executed
+    with CaptureQueriesContext(connection) as ctx:
+        result = gql_client.query(query)
+
+    # Sanity check the results
+    assert not result.errors
+    assert result.data == {
+        "projectList": [
+            {
+                "name": project.name,
+                "milestones": [
+                    {"name": milestone.name}
+                    for milestone in project.milestones.order_by("pk")],
+            }
+            for project in Project.objects.order_by("pk")
+        ]
+    }
+
+    # This is a bit crude, but all queries should have an `ORDER BY` clause
+    # This can only be true if we are handling this correctly, as the models don't
+    # have any `Meta.ordering` defined
+    for query in ctx.captured_queries:
+        assert "ORDER BY" in query["sql"]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_connection(gql_client: utils.GraphQLTestClient):
+    # TODO: Query a connection field, and a nested connection field with no ordering
+    # We expect the queries to have an `ORDER BY` clause
+    pass
+
+
+@pytest.mark.django_db(transaction=True)
+def test_paginated():
+    # TODO: Query a paginated field, and a nested paginated field with no ordering
+    # We expect the queries to have an `ORDER BY` clause
+    pass


### PR DESCRIPTION
## Description

As per #714, types for models with no default `Meta.ordering` can result in non-deterministic results. This PR adds a `.order_by("pk")` to unordered QuerySets for any list, connection, paginated or optional type. It also adds some extra fields to the `tests/projects/schema.py` GraphQL schema to enable the testing of more combinations of unordered models / types / fields.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fix #714

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Orders unordered QuerySets by primary key to ensure deterministic results for list, connection, paginated or optional types.

Bug Fixes:
- Fixes a bug where models with no default `Meta.ordering` can result in non-deterministic results.

Tests:
- Adds tests to verify that queries on list fields and nested list fields with no ordering have an `ORDER BY` clause.

## Summary by Sourcery

Ensures deterministic ordering of query results by ordering unordered QuerySets by their primary key. This change affects list, connection, paginated, and optional types, guaranteeing consistent results when no explicit ordering is defined in the model's Meta class.

Bug Fixes:
- Fixes non-deterministic results for models without default ordering in Meta, ensuring consistent query results.

Enhancements:
- Adds primary key ordering to unordered QuerySets for list, connection, paginated, or optional types.

Tests:
- Adds tests to verify that queries on list fields and nested list fields with no ordering have an `ORDER BY` clause.