### PR TITLE
Improve fallback primary key ordering unit tests

### DIFF
--- a/tests/projects/faker.py
+++ b/tests/projects/faker.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Group
 from factory.declarations import Iterator, LazyFunction, Sequence, SubFactory
 from factory.faker import Faker
 
-from .models import Favorite, Issue, Milestone, Project, Tag
+from .models import Favorite, Issue, Milestone, Project, Quiz, Tag
 
 _T = TypeVar("_T")
 User = get_user_model()
@@ -91,3 +91,10 @@ class TagFactory(_BaseFactory[Tag]):
         model = Tag
 
     name = Sequence(lambda n: f"Tag {n}")
+
+
+class QuizFactory(_BaseFactory[Quiz]):
+    class Meta:
+        model = Quiz
+
+    title = Sequence(lambda n: f"Quiz {n}")

--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -93,6 +93,7 @@ class Favorite(models.Model):
 
     class Meta:
         # Needed to allow type's get_queryset() to access a model's custom QuerySet
+        ordering = ("name",)
         base_manager_name = "objects"
 
     id = models.BigAutoField(

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -292,6 +292,15 @@ class QuizType(relay.Node):
     title: strawberry.auto
     sequence: strawberry.auto
 
+    @classmethod
+    def get_queryset(
+        cls,
+        queryset: QuerySet[Quiz],
+        info: Info,
+        **kwargs,
+    ) -> QuerySet[Quiz]:
+        return queryset.order_by("title")
+
 
 @strawberry_django.partial(Tag)
 class TagInputPartial(NodeInputPartial):
@@ -431,6 +440,8 @@ class Query:
     project_conn: ProjectConnection = strawberry_django.connection()
     tag_conn: ListConnectionWithTotalCount[TagType] = strawberry_django.connection()
     staff_conn: ListConnectionWithTotalCount[StaffType] = strawberry_django.connection()
+
+    quiz_list: list[QuizType] = strawberry_django.field()
 
     # Login required to resolve
     issue_login_required: IssueType = strawberry_django.node(

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -769,6 +769,7 @@ type Query {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): StaffTypeConnection!
+  quizList: [QuizType!]!
   issueLoginRequired(
     """The ID of the object."""
     id: GlobalID!


### PR DESCRIPTION
## Description

PR #715 introduced default fallback primary key ordering for unordered querysets. This PR adds some extra unit tests, to ensure that pre-existing ordering from various sources is still respected.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Tests:
- Adds tests to verify that fallback primary key ordering respects pre-existing ordering from various sources, including default model ordering, `get_queryset` ordering, and GraphQL ordering.