### PR TITLE
Fix unnecessary window pagination being used

### DIFF
--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -360,8 +360,10 @@ class StrawberryDjangoPagination(StrawberryDjangoFieldBase):
         # Add implicit pagination if this field is not a list
         # that way when first() / get() is called on the QuerySet it does not cause extra queries
         # and we don't prefetch more than necessary
-        if not pagination and not (
-            self.is_list or self.is_paginated or self.is_connection
+        if (
+            not pagination
+            and not (self.is_list or self.is_paginated or self.is_connection)
+            and not _strawberry_related_field_id
         ):
             if self.is_optional:
                 pagination = OffsetPaginationInput(offset=0, limit=1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

This was broken by me in #675, I apologize.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
When prefetching, `strawberry-django` currently always uses window pagination, even though it is not necessary in most situations. This was broken in #675. 
In theory there are situation where using Window pagination here makes sense, but I am not sure it is worth it to try and detect those, so I am just disabling the automatic pagination from #675 for prefetches.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Fixes unnecessary window pagination being used when prefetching data.