### PR TITLE
[Showcase] Model instance creation flood with prefetched

### DIFF
--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -59,7 +59,10 @@ class Project(NamedModel):
     def is_small(self) -> bool:
         return self._milestone_count < 3  # type: ignore
 
+
 count = 0
+
+
 class Milestone(NamedModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/projects/models.py
+++ b/tests/projects/models.py
@@ -59,8 +59,14 @@ class Project(NamedModel):
     def is_small(self) -> bool:
         return self._milestone_count < 3  # type: ignore
 
-
+count = 0
 class Milestone(NamedModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        global count
+        count += 1
+        print(count)
+
     issues: "RelatedManager[Issue]"
 
     id = models.BigAutoField(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1791,7 +1791,9 @@ def test_prefetch_multi_field_single_required_multiple_returned(
             "path": ["milestone", "firstIssueRequired"],
         }
     ]
-### NEW
+
+
+# NEW
 
 
 @pytest.mark.django_db(transaction=True)
@@ -1821,7 +1823,7 @@ def test_prefetch_multi_field_single_required_multiple_returned_num_instances(
       }
     """
 
-    #with assert_num_queries(2):
+    # with assert_num_queries(2):
     res = gql_client.query(
         query, assert_no_errors=False, variables={"id": milestone_id}
     )


### PR DESCRIPTION
## Description

<see Github issue in django-strawberry repo>

## Summary by Sourcery

Add a test to check the number of model instances created during prefetching and enhance the Milestone model to track instance creation count.

Enhancements:
- Add a counter to track the number of Milestone instances created, printing the count each time a new instance is initialized.

Tests:
- Add a test to verify the number of model instances created when prefetching multiple fields with a single required field and multiple returned instances.