### PR TITLE
fix: Ensure max_results is consistently applied for connections

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -448,6 +448,7 @@ class StrawberryDjangoConnectionExtension(relay.ConnectionExtension):
                     after=after,
                     first=first,
                     last=last,
+                    max_results=self.max_results,
                 )
                 if inspect.isawaitable(resolved):
                     resolved = await resolved
@@ -463,6 +464,7 @@ class StrawberryDjangoConnectionExtension(relay.ConnectionExtension):
             after=after,
             first=first,
             last=last,
+            max_results=self.max_results,
         )
 
 


### PR DESCRIPTION
fix https://github.com/strawberry-graphql/strawberry-django/issues/726

## Summary by Sourcery

Bug Fixes:
- Ensure max_results is consistently applied in both synchronous and asynchronous resolver paths for GraphQL connections