### PR TITLE
Fix duplicate LOOKUP_SEP being used when field hints are used with polymorphic queries

### DIFF
--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -965,7 +965,8 @@ def _get_hints_from_django_field(
     if (model_field := get_model_field(model, model_fieldname)) is None:
         return None
 
-    path = f"{prefix}{model_fieldname}"
+    lookup_prefix = prefix + LOOKUP_SEP if prefix else ""
+    path = f"{lookup_prefix}{model_fieldname}"
 
     if isinstance(model_field, (models.ForeignKey, OneToOneRel)):
         store = _get_hints_from_django_foreign_key(
@@ -1071,6 +1072,8 @@ def _get_model_hints(
                 # These must be prefixed with app_label__ModelName___ (note three underscores)
                 # This is a special syntax for django-polymorphic:
                 # https://django-polymorphic.readthedocs.io/en/stable/advanced.html#polymorphic-filtering-for-fields-in-inherited-classes
+                # "prefix" however is written in terms of not including the final LOOKUP_SEP (i.e. "__")
+                # So we don't include the final __ here.
                 return _get_model_hints(
                     dj_definition.model,
                     schema,
@@ -1078,7 +1081,7 @@ def _get_model_hints(
                     parent_type=parent_type,
                     info=info,
                     config=config,
-                    prefix=f"{prefix}{dj_definition.model._meta.app_label}__{dj_definition.model._meta.model_name}___",
+                    prefix=f"{prefix}{dj_definition.model._meta.app_label}__{dj_definition.model._meta.model_name}_",
                 )
             if is_inheritance_manager(model._default_manager) and (
                 path_from_parent := dj_definition.model._meta.get_path_from_parent(
@@ -1088,7 +1091,6 @@ def _get_model_hints(
                 prefix = LOOKUP_SEP.join(
                     p.join_field.get_accessor_name() for p in path_from_parent
                 )
-                prefix += LOOKUP_SEP
                 return _get_model_hints(
                     dj_definition.model,
                     schema,
@@ -1105,14 +1107,17 @@ def _get_model_hints(
     if dj_type_store:
         store |= dj_type_store
 
+    lookup_prefix = prefix + LOOKUP_SEP if prefix else ""
     # Make sure that the model's pk is always selected when using only
     pk = model._meta.pk
     if pk is not None:
-        store.only.append(prefix + pk.attname)
+        store.only.append(lookup_prefix + pk.attname)
 
     # If this is a polymorphic Model, make sure to select its content type
     if is_polymorphic_model(model):
-        store.only.extend(prefix + f for f in model.polymorphic_internal_model_fields)
+        store.only.extend(
+            lookup_prefix + f for f in model.polymorphic_internal_model_fields
+        )
 
     selections = [
         field_data

--- a/tests/polymorphism/models.py
+++ b/tests/polymorphism/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from polymorphic.models import PolymorphicModel
 
+from strawberry_django.descriptors import model_property
+
 
 class Company(models.Model):
     name = models.CharField(max_length=100)
@@ -24,6 +26,10 @@ class Project(PolymorphicModel):
 class ArtProject(Project):
     artist = models.CharField(max_length=30)
     art_style = models.CharField(max_length=30)
+
+    @model_property(only=("art_style",))
+    def art_style_upper(self) -> str:
+        return self.art_style.upper()
 
 
 class ResearchProject(Project):

--- a/tests/polymorphism/schema.py
+++ b/tests/polymorphism/schema.py
@@ -24,10 +24,19 @@ from .models import (
 class ProjectType:
     topic: strawberry.auto
 
+    @strawberry_django.field(only=("topic",))
+    def topic_upper(self) -> str:
+        return self.topic.upper()
+
 
 @strawberry_django.type(ArtProject)
 class ArtProjectType(ProjectType):
     artist: strawberry.auto
+    art_style_upper: strawberry.auto
+
+    @strawberry_django.field(only=("artist",))
+    def artist_upper(self) -> str:
+        return self.artist.upper()
 
 
 @strawberry_django.type(ResearchProject)

--- a/tests/polymorphism_inheritancemanager/models.py
+++ b/tests/polymorphism_inheritancemanager/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from model_utils.managers import InheritanceManager
 
+from strawberry_django.descriptors import model_property
+
 
 class Company(models.Model):
     name = models.CharField(max_length=100)
@@ -30,6 +32,10 @@ class Project(models.Model):
 class ArtProject(Project):
     artist = models.CharField(max_length=30)
     art_style = models.CharField(max_length=30)
+
+    @model_property(only=("art_style",))
+    def art_style_upper(self) -> str:
+        return self.art_style.upper()
 
 
 class ResearchProject(Project):

--- a/tests/polymorphism_inheritancemanager/schema.py
+++ b/tests/polymorphism_inheritancemanager/schema.py
@@ -24,10 +24,19 @@ from .models import (
 class ProjectType:
     topic: strawberry.auto
 
+    @strawberry_django.field(only=("topic",))
+    def topic_upper(self) -> str:
+        return self.topic.upper()
+
 
 @strawberry_django.type(ArtProject)
 class ArtProjectType(ProjectType):
     artist: strawberry.auto
+    art_style_upper: strawberry.auto
+
+    @strawberry_django.field(only=("artist",))
+    def artist_upper(self) -> str:
+        return self.artist.upper()
 
 
 @strawberry_django.type(ResearchProject)


### PR DESCRIPTION
When an optimizer `only` hint was used in a polymorphic model, the optimizer used an incorrect prefix.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #733

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
