### PR TITLE
Fix "ordering" for connections and offset_paginated

### DIFF
--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -43,6 +43,7 @@ _QS = TypeVar("_QS", bound="QuerySet")
 _SFT = TypeVar("_SFT", bound=StrawberryField)
 
 ORDER_ARG = "order"
+ORDERING_ARG = "ordering"
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

"ordering" was never properly implemented for connections and offset_paginated. This PR corrects this.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #740 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Implement proper ordering support for connections and offset paginated fields in the Strawberry Django GraphQL library

Bug Fixes:
- Fixed the lack of proper ordering implementation for connections and offset paginated fields

Enhancements:
- Added support for 'ordering' argument in connection and offset paginated fields
- Extended field resolution to handle new ordering mechanism

Tests:
- Added comprehensive test cases for ordering on different field types
- Verified ordering works for standard fields, connections, and paginated fields