### PR TITLE
Optimizer: Pass accurate "info" parameter to PrefetchCallable and AnnotateCallable

### DIFF
--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -20,6 +20,7 @@ from strawberry.types.field import UNRESOLVED, StrawberryField
 from strawberry.types.union import StrawberryUnion
 from strawberry.utils.inspect import get_specialized_type_var_map
 
+from strawberry_django.descriptors import ModelProperty
 from strawberry_django.resolvers import django_resolver
 from strawberry_django.utils.typing import (
     WithStrawberryDjangoObjectDefinition,
@@ -138,6 +139,13 @@ class StrawberryDjangoFieldBase(StrawberryField):
             django_type.__strawberry_django_definition__.model
             if django_type is not None
             else None
+        )
+
+    @functools.cached_property
+    def has_model_property(self) -> bool:
+        django_definition = self.origin_django_type
+        return django_definition is not None and isinstance(
+            getattr(django_definition.model, self.python_name, None), ModelProperty
         )
 
     @functools.cached_property

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -286,7 +286,7 @@ class StrawberryDjangoFieldFilters(StrawberryDjangoFieldBase):
     @property
     def arguments(self) -> list[StrawberryArgument]:
         arguments = []
-        if self.base_resolver is None:
+        if self.base_resolver is None and not self.has_model_property:
             filters = self.get_filters()
             origin = cast("WithStrawberryObjectDefinition", self.origin)
             is_root_query = origin.__strawberry_definition__.name == "Query"

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
+    Optional,
     TypeVar,
     cast,
 )
@@ -697,10 +698,10 @@ def _get_hints_from_field(
     f_info: GraphQLResolveInfo,
     prefix: str = "",
 ) -> OptimizerStore | None:
-    if not (field_store := getattr(field, "store", None)):
+    if not (
+        field_store := cast("Optional[OptimizerStore]", getattr(field, "store", None))
+    ):
         return None
-
-    field_store: OptimizerStore
 
     if len(field_store.annotate) == 1 and _annotate_placeholder in field_store.annotate:
         # This is a special case where we need to update the field name,
@@ -714,7 +715,11 @@ def _get_hints_from_field(
             field.name: field_store.annotate[_annotate_placeholder],
         }
 
-    return field_store.with_prefix(prefix, info=f_info) if prefix else field_store.with_resolved_callables(f_info)
+    return (
+        field_store.with_prefix(prefix, info=f_info)
+        if prefix
+        else field_store.with_resolved_callables(f_info)
+    )
 
 
 def _get_hints_from_model_property(
@@ -731,7 +736,11 @@ def _get_hints_from_model_property(
         and model_attr.store
     ):
         attr_store = model_attr.store
-        store = attr_store.with_prefix(prefix, info=f_info) if prefix else attr_store.with_resolved_callables(f_info)
+        store = (
+            attr_store.with_prefix(prefix, info=f_info)
+            if prefix
+            else attr_store.with_resolved_callables(f_info)
+        )
     else:
         store = None
 

--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -301,11 +301,11 @@ class StrawberryDjangoFieldOrdering(StrawberryDjangoFieldBase):
     @property
     def arguments(self) -> list[StrawberryArgument]:
         arguments = []
-        if self.base_resolver is None and self.is_list:
+        if self.base_resolver is None and self.is_list and not self.has_model_property:
             order = self.get_order()
             if order and order is not UNSET:
                 arguments.append(argument("order", order, is_optional=True))
-        if self.base_resolver is None and self.is_list:
+        if self.base_resolver is None and self.is_list and not self.has_model_property:
             ordering = self.get_ordering()
             if ordering is not None:
                 arguments.append(

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -306,7 +306,11 @@ class StrawberryDjangoPagination(StrawberryDjangoFieldBase):
     @property
     def arguments(self) -> list[StrawberryArgument]:
         arguments = []
-        if self.base_resolver is None and (self.is_list or self.is_paginated):
+        if (
+            self.base_resolver is None
+            and (self.is_list or self.is_paginated)
+            and not self.has_model_property
+        ):
             pagination = self.get_pagination()
             if pagination is not None:
                 arguments.append(

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -20,7 +20,9 @@ from django.db.models import (
 )
 from django.db.models.functions import Now
 from django.db.models.query import QuerySet
+from graphql import GraphQLResolveInfo
 from strawberry import UNSET, relay
+from strawberry.types import get_object_definition
 from strawberry.types.info import Info
 
 import strawberry_django
@@ -28,7 +30,7 @@ from strawberry_django import mutations
 from strawberry_django.auth.queries import get_current_user
 from strawberry_django.fields.types import ListInput, NodeInput, NodeInputPartial
 from strawberry_django.mutations import resolvers
-from strawberry_django.optimizer import DjangoOptimizerExtension
+from strawberry_django.optimizer import DjangoOptimizerExtension, _get_selections, _get_field_data, optimize
 from strawberry_django.pagination import OffsetPaginated
 from strawberry_django.permissions import (
     HasPerm,
@@ -83,10 +85,10 @@ class StaffType(relay.Node):
 
     @classmethod
     def get_queryset(
-        cls,
-        queryset: QuerySet[AbstractUser],
-        info: Info,
-        **kwargs,
+            cls,
+            queryset: QuerySet[AbstractUser],
+            info: Info,
+            **kwargs,
     ) -> QuerySet[AbstractUser]:
         return queryset.filter(is_staff=True)
 
@@ -122,6 +124,32 @@ class ProjectType(relay.Node, Named):
     milestones_paginated: OffsetPaginated["MilestoneType"] = (
         strawberry_django.offset_paginated(field_name="milestones")
     )
+
+    @staticmethod
+    def _prefetch_custom_milestones(info: GraphQLResolveInfo) -> Prefetch:
+        print(f"custom pfetch path={info.path.as_list()}, parent={info.parent_type}, return={info.return_type}")
+        selection = next(iter((
+            field_data
+            for f_selection in _get_selections(info, info.return_type).values()
+            if (
+                   field_data := _get_field_data(
+                       f_selection,
+                       get_object_definition(ProjectType, strict=True),
+                       schema,
+                       parent_type=info.parent_type,
+                       info=info,
+                   )
+               ) is not None and field_data[2].name.value == info.path.key
+        )))
+        qs = Milestone.objects.all()
+        # if selection:
+        #     qs = optimize(qs, selection[3])
+        return Prefetch("milestones", queryset=qs, to_attr="custom_milestones")
+
+    @strawberry_django.field(prefetch_related=_prefetch_custom_milestones)
+    @staticmethod
+    def custom_milestones(parent: strawberry.Parent, info: Info) -> list["MilestoneType"]:
+        return parent.custom_milestones
 
 
 @strawberry_django.filter(Milestone, lookups=True)
@@ -294,10 +322,10 @@ class QuizType(relay.Node):
 
     @classmethod
     def get_queryset(
-        cls,
-        queryset: QuerySet[Quiz],
-        info: Info,
-        **kwargs,
+            cls,
+            queryset: QuerySet[Quiz],
+            info: Info,
+            **kwargs,
     ) -> QuerySet[Quiz]:
         return queryset.order_by("title")
 
@@ -574,14 +602,14 @@ class Mutation:
 
     @mutations.input_mutation(handle_django_errors=True)
     def create_project(
-        self,
-        info: Info,
-        name: str,
-        cost: Annotated[
-            decimal.Decimal,
-            strawberry.argument(description="The project's cost"),
-        ],
-        due_date: Optional[datetime.datetime] = None,
+            self,
+            info: Info,
+            name: str,
+            cost: Annotated[
+                decimal.Decimal,
+                strawberry.argument(description="The project's cost"),
+            ],
+            due_date: Optional[datetime.datetime] = None,
     ) -> ProjectType:
         """Create project documentation."""
         if cost > 500:
@@ -612,10 +640,10 @@ class Mutation:
 
     @mutations.input_mutation(handle_django_errors=True)
     def create_quiz(
-        self,
-        info: Info,
-        title: str,
-        full_clean_options: bool = False,
+            self,
+            info: Info,
+            title: str,
+            full_clean_options: bool = False,
     ) -> QuizType:
         return cast(
             "QuizType",

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -22,7 +22,6 @@ from django.db.models.functions import Now
 from django.db.models.query import QuerySet
 from graphql import GraphQLResolveInfo
 from strawberry import UNSET, relay
-from strawberry.types import get_object_definition
 from strawberry.types.info import Info
 
 import strawberry_django
@@ -32,8 +31,8 @@ from strawberry_django.fields.types import ListInput, NodeInput, NodeInputPartia
 from strawberry_django.mutations import resolvers
 from strawberry_django.optimizer import (
     DjangoOptimizerExtension,
-    _get_field_data,
-    _get_selections, optimize, OptimizerStore,
+    OptimizerStore,
+    optimize,
 )
 from strawberry_django.pagination import OffsetPaginated
 from strawberry_django.permissions import (
@@ -131,12 +130,8 @@ class ProjectType(relay.Node, Named):
 
     @staticmethod
     def _prefetch_custom_milestones(info: GraphQLResolveInfo) -> Prefetch:
-        print(
-            f"custom pfetch path={info.path.as_list()}, parent={info.parent_type}, return={info.return_type}"
-        )
         qs = Milestone.objects.all()
         qs = optimize(qs, info, store=OptimizerStore.with_hints(only="project_id"))
-        print("pfetch qs=", str(qs.query))
         return Prefetch("milestones", queryset=qs, to_attr="custom_milestones")
 
     @strawberry_django.field(prefetch_related=_prefetch_custom_milestones)

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -17,7 +17,9 @@ from django.db.models import (
     Prefetch,
     Q,
     Subquery,
+    Value,
 )
+from django.db.models.fields import CharField
 from django.db.models.functions import Now
 from django.db.models.query import QuerySet
 from graphql import GraphQLResolveInfo
@@ -192,6 +194,15 @@ class MilestoneType(relay.Node, Named):
     )
     first_issue: Optional["IssueType"] = strawberry_django.field(field_name="issues")
     first_issue_required: "IssueType" = strawberry_django.field(field_name="issues")
+
+    @staticmethod
+    def _annotate_graphql_path(info: GraphQLResolveInfo):
+        return Value(
+            ",".join(map(str, info.path.as_list())),
+            output_field=CharField(max_length=255),
+        )
+
+    graphql_path: str = strawberry_django.field(annotate=_annotate_graphql_path)
     issues_paginated: OffsetPaginated["IssueType"] = strawberry_django.offset_paginated(
         field_name="issues",
         order=IssueOrder,

--- a/tests/projects/schema.py
+++ b/tests/projects/schema.py
@@ -115,6 +115,7 @@ class ProjectType(relay.Node, Named):
     cost: strawberry.auto = strawberry_django.field(extensions=[IsAuthenticated()])
     milestones: list["MilestoneType"] = strawberry_django.field(pagination=True)
     milestones_count: int = strawberry_django.field(annotate=Count("milestone"))
+    custom_milestones_model_property: strawberry.auto
     first_milestone: Optional["MilestoneType"] = strawberry_django.field(
         field_name="milestones"
     )

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -394,6 +394,7 @@ type MilestoneType implements Node & Named {
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
   firstIssue: IssueType
   firstIssueRequired: IssueType!
+  graphqlPath: String!
   issuesPaginated(pagination: OffsetPaginationInput, order: IssueOrder): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -589,6 +589,7 @@ type ProjectType implements Node & Named {
   cost: Decimal @isAuthenticated
   milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
   milestonesCount: Int!
+  customMilestonesModelProperty: [MilestoneType!]!
   firstMilestone: MilestoneType
   firstMilestoneRequired: MilestoneType!
   milestoneConn(

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -608,6 +608,7 @@ type ProjectType implements Node & Named {
     last: Int = null
   ): MilestoneTypeConnection!
   milestonesPaginated(pagination: OffsetPaginationInput, filters: MilestoneFilter, order: MilestoneOrder): MilestoneTypeOffsetPaginated!
+  customMilestones: [MilestoneType!]!
 }
 
 """An edge in a connection."""

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -182,6 +182,7 @@ type MilestoneType implements Node & Named {
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
   firstIssue: IssueType
   firstIssueRequired: IssueType!
+  graphqlPath: String!
   issuesPaginated(pagination: OffsetPaginationInput, order: IssueOrder): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter
@@ -243,6 +244,7 @@ type MilestoneTypeSubclass implements Node & Named {
   issues(filters: IssueFilter, order: IssueOrder, pagination: OffsetPaginationInput): [IssueType!]!
   firstIssue: IssueType
   firstIssueRequired: IssueType!
+  graphqlPath: String!
   issuesPaginated(pagination: OffsetPaginationInput, order: IssueOrder): IssueTypeOffsetPaginated!
   issuesWithFilters(
     filters: IssueFilter

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -367,6 +367,7 @@ type ProjectType implements Node & Named {
   cost: Decimal @isAuthenticated
   milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
   milestonesCount: Int!
+  customMilestonesModelProperty: [MilestoneType!]!
   firstMilestone: MilestoneType
   firstMilestoneRequired: MilestoneType!
   milestoneConn(
@@ -399,6 +400,7 @@ type ProjectTypeSubclass implements Node & Named {
   cost: Decimal @isAuthenticated
   milestones(filters: MilestoneFilter, order: MilestoneOrder, pagination: OffsetPaginationInput): [MilestoneType!]!
   milestonesCount: Int!
+  customMilestonesModelProperty: [MilestoneType!]!
   firstMilestone: MilestoneType
   firstMilestoneRequired: MilestoneType!
   milestoneConn(

--- a/tests/projects/snapshots/schema_with_inheritance.gql
+++ b/tests/projects/snapshots/schema_with_inheritance.gql
@@ -386,6 +386,7 @@ type ProjectType implements Node & Named {
     last: Int = null
   ): MilestoneTypeConnection!
   milestonesPaginated(pagination: OffsetPaginationInput, filters: MilestoneFilter, order: MilestoneOrder): MilestoneTypeOffsetPaginated!
+  customMilestones: [MilestoneType!]!
 }
 
 type ProjectTypeSubclass implements Node & Named {
@@ -417,6 +418,7 @@ type ProjectTypeSubclass implements Node & Named {
     last: Int = null
   ): MilestoneTypeConnection!
   milestonesPaginated(pagination: OffsetPaginationInput, filters: MilestoneFilter, order: MilestoneOrder): MilestoneTypeOffsetPaginated!
+  customMilestones: [MilestoneType!]!
 }
 
 type Query {

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -13,7 +13,7 @@ from strawberry.types import ExecutionResult, get_object_definition
 
 import strawberry_django
 from strawberry_django.optimizer import DjangoOptimizerExtension
-from tests.projects.schema import IssueType, MilestoneType, StaffType
+from tests.projects.schema import IssueType, MilestoneType, StaffType, ProjectType
 
 from . import utils
 from .projects.faker import (
@@ -1858,4 +1858,117 @@ def test_no_window_function_for_normal_prefetch(
                 },
             },
         ]
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("gql_client", ("async", "sync"), indirect=True)
+def test_custom_prefetch_optimization(gql_client):
+    project = ProjectFactory.create()
+    milestone = MilestoneFactory.create(project=project, name="Hello")
+
+    project_id = str(
+        GlobalID(
+            get_object_definition(ProjectType, strict=True).name, str(project.id)
+        )
+    )
+    milestone_id = str(
+        GlobalID(
+            get_object_definition(MilestoneType, strict=True).name, str(milestone.id)
+        )
+    )
+    query = """\
+      query TestQuery($id: GlobalID!) {
+        project(id: $id) {
+          id
+          customMilestones {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    with assert_num_queries(2) as ctx:
+        res = gql_client.query(
+            query, variables={"id": project_id}, assert_no_errors=False
+        )
+    assert Milestone._meta.db_table in ctx.captured_queries[1]["sql"]
+    assert Milestone._meta.get_field("due_date").name not in ctx.captured_queries[1]["sql"]
+
+    assert res.errors is None
+    assert res.data == {
+        "project": {
+            "id": project_id,
+            "customMilestones": [
+                {
+                    "id": milestone_id,
+                    "name": milestone.name
+                }
+            ]
+        }
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("gql_client", ("sync", ), indirect=True)
+def test_custom_prefetch_optimization_nested(gql_client):
+    project = ProjectFactory.create()
+    milestone1 = MilestoneFactory.create(project=project, name="Hello1")
+    milestone2 = MilestoneFactory.create(project=project, name="Hello2")
+
+    project_id = str(
+        GlobalID(
+            get_object_definition(ProjectType, strict=True).name, str(project.id)
+        )
+    )
+    milestone1_id = str(
+        GlobalID(
+            get_object_definition(MilestoneType, strict=True).name, str(milestone1.id)
+        )
+    )
+    milestone2_id = str(
+        GlobalID(
+            get_object_definition(MilestoneType, strict=True).name, str(milestone2.id)
+        )
+    )
+    query = """\
+      query TestQuery($id: GlobalID!) {
+        milestone(id: $id) {
+          id
+          project {
+            id
+            customMilestones {
+                id name
+              }
+          }
+        }
+      }
+    """
+
+    with assert_num_queries(2) as ctx:
+        res = gql_client.query(
+            query, variables={"id": milestone1_id}, assert_no_errors=False
+        )
+    assert Milestone._meta.db_table in ctx.captured_queries[1]["sql"]
+    assert Milestone._meta.get_field("due_date").name not in ctx.captured_queries[1]["sql"]
+
+    assert res.errors is None
+    assert res.data == {
+        "milestone": {
+            "id": milestone1_id,
+            "project": {
+                "id": project_id,
+                "customMilestones": [
+                    {
+                        "id": milestone1_id,
+                        "name": milestone1.name
+                    },
+                    {
+                        "id": milestone2_id,
+                        "name": milestone2.name
+                    },
+                ]
+            }
+        }
     }

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1862,7 +1862,7 @@ def test_no_window_function_for_normal_prefetch(
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.parametrize("gql_client", ("sync",), indirect=True)
+@pytest.mark.parametrize("gql_client", ["async", "sync"], indirect=True)
 def test_custom_prefetch_optimization(gql_client):
     project = ProjectFactory.create()
     milestone = MilestoneFactory.create(project=project, name="Hello")
@@ -1906,7 +1906,7 @@ def test_custom_prefetch_optimization(gql_client):
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.parametrize("gql_client", ("sync",), indirect=True)
+@pytest.mark.parametrize("gql_client", ["async", "sync"], indirect=True)
 def test_custom_prefetch_optimization_nested(gql_client):
     project = ProjectFactory.create()
     milestone1 = MilestoneFactory.create(project=project, name="Hello1")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,6 @@ import contextvars
 import dataclasses
 import inspect
 import warnings
-from contextlib import AbstractContextManager
 from typing import (
     Any,
     Optional,
@@ -93,10 +92,11 @@ def deep_tuple_to_list(data: tuple) -> list:
     return return_list
 
 
-class AsyncCaptureQueriesContext(AbstractContextManager[CaptureQueriesContext]):
+class AsyncCaptureQueriesContext:
     wrapped: CaptureQueriesContext
 
     def __init__(self, using: str):
+        super().__init__()
         self.using = using
 
     @sync_to_async


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

The optimizer allows dynamic annotations or prefetches by passing a callable. Currently this callable does not always receive an accurate `GraphQLResolveInfo`.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

The optimizer is not consistent in when it resolves dynamic prefetch_related or annotate callables. Sometimes they are resolved immediately, with the correctly scoped info object, but sometimes they are only resolved late, when the optimizer store is applied. In the latter case, the top level Info object is passed, which is incorrect.

This change updates the opimizer to always resolve the callables immediately when a field is looked at. This allows them to receive the correctly scoped info object. This is achieved by a new method `with_resolved_callables` in `OptimizerStore`, which resolves any callables.

To write correct tests for this feature, I required access to the SQL queries issued by the optimizer. This is done by `CaptureQueriesContext`, however this feature did not work in an async context. I have fixed this, so `assert_num_queries` now also works in async mode.

Additionally, I found that Strawberry Django will add `filter` and `ordering` arguments to fields that point to a `@model_property`. This is not useful, because the model_property effectively acts as a custom resolver. I have added an additional check to not add these arguments if the field points to a model_property.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #697 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
