### PR TITLE
filters in mutation default required, and add setting ALLOW_MUTATIONS_WITHOUT_FILTERS to control

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -317,11 +317,13 @@ class StrawberryDjangoFieldFilters(StrawberryDjangoFieldBase):
             elif filters is not None and self.is_list:
                 is_optional = True
                 from .mutations.fields import DjangoMutationBase
+
                 if isinstance(self, DjangoMutationBase):
                     settings = strawberry_django_settings()
-                    is_optional = settings['ALLOW_MUTATIONS_WITHOUT_FILTERS']
-                arguments.append(argument(
-                    FILTERS_ARG, filters, is_optional=is_optional))
+                    is_optional = settings["ALLOW_MUTATIONS_WITHOUT_FILTERS"]
+                arguments.append(
+                    argument(FILTERS_ARG, filters, is_optional=is_optional)
+                )
 
         return super().arguments + arguments
 

--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -315,7 +315,13 @@ class StrawberryDjangoFieldFilters(StrawberryDjangoFieldBase):
                     argument(settings["DEFAULT_PK_FIELD_NAME"], strawberry.ID)
                 )
             elif filters is not None and self.is_list:
-                arguments.append(argument(FILTERS_ARG, filters, is_optional=True))
+                is_optional = True
+                from .mutations.fields import DjangoMutationBase
+                if isinstance(self, DjangoMutationBase):
+                    settings = strawberry_django_settings()
+                    is_optional = settings['ALLOW_MUTATIONS_WITHOUT_FILTERS']
+                arguments.append(argument(
+                    FILTERS_ARG, filters, is_optional=is_optional))
 
         return super().arguments + arguments
 

--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -46,6 +46,9 @@ class StrawberryDjangoSettings(TypedDict):
     #: to set it to unlimited.
     PAGINATION_DEFAULT_LIMIT: Optional[int]
 
+    # If True, filters used in mutations can be omitted
+    ALLOW_MUTATIONS_WITHOUT_FILTERS: bool
+
 
 DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
     FIELD_DESCRIPTION_FROM_HELP_TEXT=False,
@@ -57,6 +60,7 @@ DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
     DEFAULT_PK_FIELD_NAME="pk",
     USE_DEPRECATED_FILTERS=False,
     PAGINATION_DEFAULT_LIMIT=100,
+    ALLOW_MUTATIONS_WITHOUT_FILTERS=False,
 )
 
 

--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -46,7 +46,7 @@ class StrawberryDjangoSettings(TypedDict):
     #: to set it to unlimited.
     PAGINATION_DEFAULT_LIMIT: Optional[int]
 
-    # If True, filters used in mutations can be omitted
+    #: If True, filters used in mutations can be omitted
     ALLOW_MUTATIONS_WITHOUT_FILTERS: bool
 
 

--- a/tests/mutations/test_mutations.py
+++ b/tests/mutations/test_mutations.py
@@ -162,7 +162,8 @@ def test_create_many(mutation):
 
 def test_update(mutation, fruits):
     result = mutation(
-        '{ fruits: updateFruits(data: { name: "orange" }, filters: {}) { id name } }')
+        '{ fruits: updateFruits(data: { name: "orange" }, filters: {}) { id name } }'
+    )
     assert not result.errors
     assert result.data["fruits"] == [
         {"id": "1", "name": "orange"},

--- a/tests/mutations/test_mutations.py
+++ b/tests/mutations/test_mutations.py
@@ -161,7 +161,8 @@ def test_create_many(mutation):
 
 
 def test_update(mutation, fruits):
-    result = mutation('{ fruits: updateFruits(data: { name: "orange" }) { id name } }')
+    result = mutation(
+        '{ fruits: updateFruits(data: { name: "orange" }, filters: {}) { id name } }')
     assert not result.errors
     assert result.data["fruits"] == [
         {"id": "1", "name": "orange"},
@@ -177,7 +178,7 @@ def test_update(mutation, fruits):
 
 def test_update_m2m_with_validation_error(mutation, fruit):
     result = mutation(
-        '{ fruits: updateFruits(data: { types: [{ name: "rotten"} ] }) { id types {'
+        '{ fruits: updateFruits(data: { types: [{ name: "rotten"} ] }, filters: {}) { id types {'
         " name } }}",
     )
     assert result.errors
@@ -186,7 +187,7 @@ def test_update_m2m_with_validation_error(mutation, fruit):
 
 def test_update_m2m_with_new_different_objects(mutation, fruit):
     result = mutation(
-        '{ fruits: updateFruits(data: { types: [{name: "apple"}, {name: "strawberry"}]}) { id types { id name }}}'
+        '{ fruits: updateFruits(data: { types: [{name: "apple"}, {name: "strawberry"}]}, filters: {}) { id types { id name }}}'
     )
     assert not result.errors
     assert result.data["fruits"][0]["types"] == [
@@ -195,7 +196,7 @@ def test_update_m2m_with_new_different_objects(mutation, fruit):
     ]
 
     result = mutation(
-        '{ fruits: updateFruits(data: { types: [{id: "1", name: "apple updated"}, {name: "raspberry"}]}) { id types { id name }}}'
+        '{ fruits: updateFruits(data: { types: [{id: "1", name: "apple updated"}, {name: "raspberry"}]}, filters: {}) { id types { id name }}}'
     )
 
     assert result.data["fruits"][0]["types"] == [
@@ -206,7 +207,7 @@ def test_update_m2m_with_new_different_objects(mutation, fruit):
 
 def test_update_m2m_with_duplicates(mutation, fruit):
     result = mutation(
-        '{ fruits: updateFruits(data: { types: [{name: "apple"}, {name: "apple"}]}) { id types { id name }}}'
+        '{ fruits: updateFruits(data: { types: [{name: "apple"}, {name: "apple"}]}, filters: {}) { id types { id name }}}'
     )
     assert not result.errors
     assert result.data["fruits"][0]["types"] == [
@@ -241,7 +242,7 @@ def test_update_with_filters(mutation, fruits):
 
 
 def test_delete(mutation, fruits):
-    result = mutation("{ fruits: deleteFruits { id name } }")
+    result = mutation("{ fruits: deleteFruits(filters: {}) { id name } }")
     assert not result.errors
     assert result.data["fruits"] == [
         {"id": "1", "name": "strawberry"},

--- a/tests/mutations/test_relationship.py
+++ b/tests/mutations/test_relationship.py
@@ -30,13 +30,13 @@ def test_create_one_to_many(mutation, color):
 
 def test_update_one_to_many(mutation, fruit, color):
     result = mutation(
-        "{ fruits: updateFruits(data: { color: { set: 1 } }) { color { name } } }",
+        "{ fruits: updateFruits(data: { color: { set: 1 } }, filters: {}) { color { name } } }",
     )
     assert not result.errors
     assert result.data["fruits"] == [{"color": {"name": color.name}}]
 
     result = mutation(
-        "{ fruits: updateFruits(data: { color: { set: null } }) { color { name } } }",
+        "{ fruits: updateFruits(data: { color: { set: null } }, filters: {}) { color { name } } }",
     )
     assert not result.errors
     assert result.data["fruits"] == [{"color": None}]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -31,6 +31,7 @@ def test_non_defaults():
             DEFAULT_PK_FIELD_NAME="id",
             USE_DEPRECATED_FILTERS=True,
             PAGINATION_DEFAULT_LIMIT=250,
+            ALLOW_MUTATIONS_WITHOUT_FILTERS=True,
         ),
     ):
         assert (
@@ -45,5 +46,6 @@ def test_non_defaults():
                 DEFAULT_PK_FIELD_NAME="id",
                 USE_DEPRECATED_FILTERS=True,
                 PAGINATION_DEFAULT_LIMIT=250,
+                ALLOW_MUTATIONS_WITHOUT_FILTERS=True,
             )
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is to prevent front-end developers from accidentally modifying or deleting the entire table.

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

close #751

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Enforce requiring filters in update and delete mutations by default to prevent unintended bulk operations, and provide a new configuration option to override this behavior.

Enhancements:
- Require filters argument for all mutations by default to avoid accidental full-table modifications.
- Introduce ALLOW_MUTATIONS_WITHOUT_FILTERS setting to permit omitting filters when explicitly enabled.
- Add ALLOW_MUTATIONS_WITHOUT_FILTERS default configuration (false) to project settings.

Tests:
- Update mutation tests to include empty filters in update and delete operations.
- Add tests for the ALLOW_MUTATIONS_WITHOUT_FILTERS setting in the settings suite.