### PR TITLE
Add support for AND/OR filters to be lists

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import operator
 import inspect
 import warnings
 from enum import Enum
@@ -194,19 +195,36 @@ def process_filters(
             if field_value:
                 queryset = queryset.distinct()
         elif field_name in ("AND", "OR", "NOT"):  # noqa: PLR6201
-            assert has_object_definition(field_value)
+            if isinstance(field_value, list):
+                values = field_value
+            else:
+                values = [field_value]
+            all_q = []
+            for value in values:
+                assert has_object_definition(value)
 
-            queryset, sub_q = process_filters(
-                cast("WithStrawberryObjectDefinition", field_value),
-                queryset,
-                info,
-                prefix,
-            )
+                queryset, sub_q_for_value = process_filters(
+                    cast("WithStrawberryObjectDefinition", value),
+                    queryset,
+                    info,
+                    prefix,
+                )
+                all_q.append(sub_q_for_value)
             if field_name == "AND":
+                sub_q = functools.reduce(operator.and_ , all_q)
                 q &= sub_q
             elif field_name == "OR":
-                q |= sub_q
+                sub_q = functools.reduce(operator.or_, all_q)
+                if isinstance(field_value, list):
+                    # The behavior of AND/OR/NOT with a list of values means AND/OR/NOT
+                    # with respect to the list members but AND with respect to other 
+                    # filters
+                    q &= sub_q
+                else:
+                    q |= sub_q
             elif field_name == "NOT":
+                # Whether this is an AND or OR operation is undefined in the spec and implementation specific
+                sub_q = functools.reduce(operator.or_, all_q)
                 q &= ~sub_q
             else:
                 assert_never(field_name)

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -119,10 +119,10 @@ def _process_type(
     if is_filter:
         cls_annotations.update(
             {
-                "AND": Optional[Self],  # type: ignore
-                "OR": Optional[Self],  # type: ignore
-                "NOT": Optional[Self],  # type: ignore
-                "DISTINCT": Optional[bool],
+                "AND": existing_annotations.get("AND").annotation if existing_annotations.get("AND") else Optional[Self],  # type: ignore
+                "OR": existing_annotations.get("OR").annotation if existing_annotations.get("OR") else Optional[Self],  # type: ignore
+                "NOT": existing_annotations.get("NOT").annotation if existing_annotations.get("NOT") else Optional[Self],  # type: ignore
+                "DISTINCT": existing_annotations.get("DISTINCT").annotation if existing_annotations.get("DISTINCT") else Optional[bool], # type: ignore
             },
         )
 

--- a/tests/types.py
+++ b/tests/types.py
@@ -32,6 +32,11 @@ class FruitType:
     fruits: list[Fruit]
 
 
+@strawberry_django.type(models.Vegetable)
+class Vegetable:
+    id: auto
+    name: auto
+
 @strawberry_django.type(models.TomatoWithRequiredPicture, fields="__all__")
 class TomatoWithRequiredPictureType:
     pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Currently, AND and OR filters must be an object and do not support lists. This PR adds support for this common syntax such that a query like this can be used:

{
  order(
    filters: {
      state: { exact: "open" },
      OR: [
        { product: { contains: "soap" } },
        { product: { contains: "shampoo" } },
        { product: { contains: "hair" } }
      ]
    }
  ) {
    id
  }
}

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [X] I have added tests to cover my changes.
- [X] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
