### PR TITLE
fix: fix filters using lazy annotations

### DIFF
--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -191,7 +191,10 @@ class StrawberryDjangoFieldBase(StrawberryField):
         if resolved is UNRESOLVED:
             return resolved
 
-        resolved_django_type = get_django_definition(unwrap_type(resolved))
+        try:
+            resolved_django_type = get_django_definition(unwrap_type(resolved))
+        except KeyError:
+            return UNRESOLVED
 
         if self.origin_django_type and (
             # FIXME: Why does this come as Any sometimes when using future annotations?

--- a/tests/filters/test_filters_v2.py
+++ b/tests/filters/test_filters_v2.py
@@ -1,6 +1,6 @@
 # ruff: noqa: B904, BLE001, F811, PT012, A001
 from enum import Enum
-from typing import Any, Optional, cast
+from typing import Annotated, Any, Optional, cast
 
 import pytest
 import strawberry
@@ -48,7 +48,9 @@ class ColorFilter:
 @strawberry_django.filter_type(models.FruitType, lookups=True)
 class FruitTypeFilter:
     name: auto
-    fruits: Optional["FruitFilter"]
+    fruits: Optional[
+        Annotated["FruitFilter", strawberry.lazy("tests.filters.test_filters_v2")]
+    ]
 
 
 @strawberry_django.filter_type(models.Fruit, lookups=True)


### PR DESCRIPTION
Fix #764

## Summary by Sourcery

Handle missing Django type definitions when using future lazy annotations by catching KeyError and returning UNRESOLVED, and update tests to use Annotated lazy filter references.

Bug Fixes:
- Catch KeyError in resolve_type to gracefully handle unresolved lazy annotations instead of propagating the exception.

Tests:
- Update filter tests to use Annotated for lazy references to FruitFilter.