### PR TITLE
fix: handle lazy filters and ordering in strawberry_django.connection

### DIFF
--- a/strawberry_django/filters.py
+++ b/strawberry_django/filters.py
@@ -8,10 +8,12 @@ from enum import Enum
 from types import FunctionType
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Generic,
     TypeVar,
     cast,
+    get_origin,
 )
 
 import strawberry
@@ -32,6 +34,7 @@ from strawberry_django.fields.filter_order import (
 )
 from strawberry_django.utils.typing import (
     WithStrawberryDjangoObjectDefinition,
+    get_type_from_lazy_annotation,
     has_django_definition,
 )
 
@@ -287,6 +290,9 @@ def apply(
 
 class StrawberryDjangoFieldFilters(StrawberryDjangoFieldBase):
     def __init__(self, filters: type | UnsetType | None = UNSET, **kwargs):
+        if filters and get_origin(filters) is Annotated:
+            filters = get_type_from_lazy_annotation(filters) or filters
+
         if filters and not has_object_definition(filters):
             raise TypeError("filters needs to be a strawberry type")
 

--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -4,6 +4,7 @@ import dataclasses
 import enum
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Optional,
     TypeVar,
@@ -19,7 +20,7 @@ from strawberry.types.base import WithStrawberryObjectDefinition
 from strawberry.types.field import StrawberryField, field
 from strawberry.types.unset import UnsetType
 from strawberry.utils.str_converters import to_camel_case
-from typing_extensions import Self, dataclass_transform, deprecated
+from typing_extensions import Self, dataclass_transform, deprecated, get_origin
 
 from strawberry_django.fields.base import StrawberryDjangoFieldBase
 from strawberry_django.fields.filter_order import (
@@ -27,7 +28,11 @@ from strawberry_django.fields.filter_order import (
     FilterOrderField,
     FilterOrderFieldResolver,
 )
-from strawberry_django.utils.typing import is_auto, unwrap_type
+from strawberry_django.utils.typing import (
+    get_type_from_lazy_annotation,
+    is_auto,
+    unwrap_type,
+)
 
 from .arguments import argument
 
@@ -282,6 +287,12 @@ class StrawberryDjangoFieldOrdering(StrawberryDjangoFieldBase):
         ordering: type | UnsetType | None = UNSET,
         **kwargs,
     ):
+        if order and get_origin(order) is Annotated:
+            order = get_type_from_lazy_annotation(order) or order
+
+        if ordering and get_origin(ordering) is Annotated:
+            ordering = get_type_from_lazy_annotation(ordering) or ordering
+
         if order and not has_object_definition(order):
             raise TypeError("order needs to be a strawberry type")
         if ordering and not has_object_definition(ordering):

--- a/strawberry_django/utils/typing.py
+++ b/strawberry_django/utils/typing.py
@@ -9,7 +9,9 @@ from typing import (
     ClassVar,
     TypeVar,
     Union,
+    _AnnotatedAlias,
     cast,
+    get_args,
     overload,
 )
 
@@ -22,7 +24,7 @@ from strawberry.types.base import (
     StrawberryType,
     WithStrawberryObjectDefinition,
 )
-from strawberry.types.lazy_type import LazyType
+from strawberry.types.lazy_type import LazyType, StrawberryLazyReference
 from strawberry.utils.typing import is_classvar
 from typing_extensions import Protocol
 
@@ -137,3 +139,12 @@ def unwrap_type(type_):
             break
 
     return type_
+
+
+def get_type_from_lazy_annotation(type_: _AnnotatedAlias) -> type | None:
+    first, *rest = get_args(type_)
+    for arg in rest:
+        if isinstance(arg, StrawberryLazyReference):
+            return unwrap_type(arg.resolve_forward_ref(first))
+
+    return None

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -101,6 +101,16 @@ class Query:
     fruits_with_order_connection: DjangoListConnection[FruitWithOrderNode] = (
         strawberry_django.connection()
     )
+    fruits_with_lazy_order_connection: DjangoListConnection[FruitWithOrderNode] = (
+        strawberry_django.connection(
+            order=Annotated["FruitOrder", strawberry.lazy("tests.test_ordering")]
+        )
+    )
+    fruits_with_lazy_ordering_connection: DjangoListConnection[FruitWithOrderNode] = (
+        strawberry_django.connection(
+            ordering=Annotated["FruitOrder", strawberry.lazy("tests.test_ordering")]
+        )
+    )
     fruits_with_order_paginated: OffsetPaginated[FruitWithOrder] = (
         strawberry_django.offset_paginated()
     )
@@ -193,6 +203,34 @@ def test_type_ordering_connection(query, fruits):
     )
     assert not result.errors
     assert result.data["fruitsWithOrderConnection"] == {
+        "edges": [
+            {"node": {"name": "banana"}},
+            {"node": {"name": "raspberry"}},
+            {"node": {"name": "strawberry"}},
+        ]
+    }
+
+
+def test_type_lazy_ordering_connection(query, fruits):
+    result = query(
+        "{ fruitsWithLazyOrderingConnection(ordering: [{ name: ASC }]) { edges { node { name } } } }"
+    )
+    assert not result.errors
+    assert result.data["fruitsWithLazyOrderingConnection"] == {
+        "edges": [
+            {"node": {"name": "banana"}},
+            {"node": {"name": "raspberry"}},
+            {"node": {"name": "strawberry"}},
+        ]
+    }
+
+
+def test_type_lazy_order_connection(query, fruits):
+    result = query(
+        "{ fruitsWithLazyOrderConnection(ordering: [{ name: ASC }]) { edges { node { name } } } }"
+    )
+    assert not result.errors
+    assert result.data["fruitsWithLazyOrderConnection"] == {
         "edges": [
             {"node": {"name": "banana"}},
             {"node": {"name": "raspberry"}},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Adjusts `StrawberryDjangoFieldOrdering` and `StrawberryDjangoFieldFilters` to handle lazy types


<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
