### PR TITLE
Relay pagination optimizations

### DIFF
--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -588,8 +588,7 @@ def _optimize_prefetch_queryset(
                 field_def_ = connection_type_def.get_field("edges")
                 assert field_def_
                 field_ = field_def_.resolve_type(type_definition=connection_type_def)
-                while isinstance(field_, StrawberryContainer):
-                    field_ = field_.of_type
+                field_ = unwrap_type(field_)
                 edge_class = cast("Edge", field_)
 
                 slice_metadata = SliceMetadata.from_arguments(

--- a/tests/polymorphism_custom/test_optimizer.py
+++ b/tests/polymorphism_custom/test_optimizer.py
@@ -186,7 +186,7 @@ def test_polymorphic_interface_connection():
     }
     """
 
-    with assert_num_queries(2):
+    with assert_num_queries(1):
         result = schema.execute_sync(query)
     assert not result.errors
     assert result.data == {

--- a/tests/relay/test_nested_pagination.py
+++ b/tests/relay/test_nested_pagination.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from strawberry.relay import to_base64
 from strawberry.relay.types import PREFIX
@@ -8,15 +10,17 @@ from tests.projects.faker import IssueFactory, MilestoneFactory
 
 
 @pytest.mark.django_db(transaction=True)
-def test_nested_pagination(gql_client: utils.GraphQLTestClient):
+def test_nested_pagination_first(gql_client: utils.GraphQLTestClient):
     # Nested pagination with the same arguments for the parent and child connections
     query = """
       query testNestedConnectionPagination($first: Int, $after: String) {
         milestoneConn(first: $first, after: $after) {
+          totalCount
           edges {
             node {
               id
               issuesWithFilters(first: $first, after: $after) {
+                totalCount
                 edges {
                   node {
                     id
@@ -37,26 +41,151 @@ def test_nested_pagination(gql_client: utils.GraphQLTestClient):
 
     # Run the nested pagination query
     # We expect only 2 database queries if the optimizer is enabled, otherwise 3 (N+1)
-    with utils.assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 3):
+    with utils.assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 6):
         result = gql_client.query(query, {"first": 2, "after": to_base64(PREFIX, 0)})
 
     # We expect the 2nd and 3rd milestones each with their 2nd and 3rd issues
     assert not result.errors
     assert result.data == {
         "milestoneConn": {
+            "totalCount": 4,
             "edges": [
                 {
                     "node": {
                         "id": to_base64("MilestoneType", milestone.id),
                         "issuesWithFilters": {
+                            "totalCount": 4,
                             "edges": [
                                 {"node": {"id": to_base64("IssueType", issue.id)}}
                                 for issue in issues[1:3]
-                            ]
+                            ],
                         },
                     }
                 }
                 for milestone, issues in list(nested_data.items())[1:3]
-            ]
+            ],
+        }
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_nested_pagination_last_before(gql_client: utils.GraphQLTestClient):
+    query = """
+      query testNestedConnectionPagination($last: Int, $before: String) {
+        milestoneConn(last: $last, before: $before) {
+          totalCount
+          edges {
+            node {
+              id
+              issuesWithFilters(last: $last, before: $before) {
+                totalCount
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    nested_data = {
+        milestone: IssueFactory.create_batch(4, milestone=milestone)
+        for milestone in MilestoneFactory.create_batch(4)
+    }
+
+    with utils.assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 6):
+        result = gql_client.query(query, {"last": 2, "before": to_base64(PREFIX, 3)})
+
+    assert not result.errors
+    assert result.data == {
+        "milestoneConn": {
+            "totalCount": 4,
+            "edges": [
+                {
+                    "node": {
+                        "id": to_base64("MilestoneType", milestone.id),
+                        "issuesWithFilters": {
+                            "totalCount": 4,
+                            "edges": [
+                                {"node": {"id": to_base64("IssueType", issue.id)}}
+                                for issue in issues[1:3]
+                            ],
+                        },
+                    }
+                }
+                for milestone, issues in list(nested_data.items())[1:3]
+            ],
+        }
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_nested_pagination_last(gql_client: utils.GraphQLTestClient):
+    query = """
+      query testNestedConnectionPagination($last: Int) {
+        milestoneConn(last: $last) {
+          totalCount
+          edges {
+            node {
+              id
+              issuesWithFilters(last: $last) {
+                totalCount
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    nested_data = {
+        milestone: IssueFactory.create_batch(4, milestone=milestone)
+        for milestone in MilestoneFactory.create_batch(4)
+    }
+    # Expecting 3 queries when optimized due to initial COUNT query used for `before` creation
+    with utils.assert_num_queries(
+        3 if DjangoOptimizerExtension.enabled.get() else 6
+    ) as q_ctx:
+        result = gql_client.query(query, {"last": 2})
+
+    if DjangoOptimizerExtension.enabled.get():
+        # Validating that the milestoneConn query is actually LIMIT sys.maxsize - limitless
+        queries_using_maxsize = [
+            q["sql"]
+            for q in q_ctx.captured_queries
+            if f"LIMIT {sys.maxsize}" in q["sql"]
+        ]
+        assert not queries_using_maxsize, (
+            f"{len(queries_using_maxsize)} queries executed using sys.maxsize"
+            " instead of reversed pagination\nCaptured queries were:\n"
+            "{}".format("\n".join(queries_using_maxsize))
+        )
+
+    assert not result.errors
+    assert result.data == {
+        "milestoneConn": {
+            "totalCount": 4,
+            "edges": [
+                {
+                    "node": {
+                        "id": to_base64("MilestoneType", milestone.id),
+                        "issuesWithFilters": {
+                            "totalCount": 4,
+                            "edges": [
+                                {"node": {"id": to_base64("IssueType", issue.id)}}
+                                for issue in issues[-2:]
+                            ],
+                        },
+                    }
+                }
+                for milestone, issues in list(nested_data.items())[-2:]
+            ],
         }
     }

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -206,7 +206,7 @@ def test_query_forward(db, gql_client: GraphQLTestClient):
                     r["milestone"]["asyncField"] = "value: foo"
                 expected.append(r)
 
-    with assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 18):
+    with assert_num_queries(1 if DjangoOptimizerExtension.enabled.get() else 18):
         res = gql_client.query(query, {"isAsync": gql_client.is_async})
 
     assert res.data == {
@@ -268,7 +268,7 @@ def test_query_forward_with_interfaces(db, gql_client: GraphQLTestClient):
                     r["milestone"]["asyncField"] = "value: foo"
                 expected.append(r)
 
-    with assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 18):
+    with assert_num_queries(1 if DjangoOptimizerExtension.enabled.get() else 18):
         res = gql_client.query(query, {"isAsync": gql_client.is_async})
 
     assert res.data == {
@@ -338,7 +338,7 @@ def test_query_forward_with_fragments(db, gql_client: GraphQLTestClient):
                     },
                 )
 
-    with assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 56):
+    with assert_num_queries(1 if DjangoOptimizerExtension.enabled.get() else 56):
         res = gql_client.query(query)
 
     assert res.data == {
@@ -605,7 +605,7 @@ def test_query_connection_with_resolver(db, gql_client: GraphQLTestClient):
     for i in range(10):
         ProjectFactory.create(name=f"Project {i}")
 
-    with assert_num_queries(3 if DjangoOptimizerExtension.enabled.get() else 5):
+    with assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 5):
         res = gql_client.query(query)
 
     assert res.data == {

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -163,7 +163,7 @@ def test_nested_pagination_m2m(gql_client: utils.GraphQLTestClient):
     # This means that both tags share the 2nd issue
     tags[0].issues.set(issues[:2])
     tags[1].issues.set(issues[1:])
-    with utils.assert_num_queries(3 if DjangoOptimizerExtension.enabled.get() else 6):
+    with utils.assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 6):
         result = gql_client.query(
             """
             query {


### PR DESCRIPTION
## Description
Goal is to optimize relay nested and non-nested pagination when paginating backwards (via `last`) without `before`. Current behavior is to fetch entire table for this case.

Additionally added `total_count` optimization for non-nested pagination.

I am not very confident with the solutions for `total_count` in  `strawberry_django/relay/list_connection.py`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/strawberry-graphql/strawberry-django/issues/613

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Improve Relay pagination performance by enabling efficient backward pagination for last-only queries and optimizing totalCount resolution via SQL window functions to avoid full-table scans and extra COUNT queries.

Enhancements:
- Automatically inject before cursors for queries using last without a before argument and apply reversed window pagination to limit QuerySets.
- Annotate QuerySets with a strawberry-specific windowed total count (_strawberry_total_count) to serve totalCount from existing query annotations.
- Extend apply_window_pagination to support reversed ordering for backward pagination scenarios.

Tests:
- Add tests for nested backward pagination and non-nested totalCount optimizations.
- Update expected database query counts in existing pagination and optimizer tests to reflect the new optimizations.