### PR TITLE
Fix typo in depecation message for order decorator

### DIFF
--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -716,7 +716,7 @@ def field(
 
     if order:
         warnings.warn(
-            "strawberry_django.order is deprecated in favor of strawberry_django.ordering.",
+            "strawberry_django.order is deprecated in favor of strawberry_django.order_type.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -429,7 +429,7 @@ def order_type(
     ),
 )
 @deprecated(
-    "strawberry_django.order is deprecated in favor of strawberry_django.ordering."
+    "strawberry_django.order is deprecated in favor of strawberry_django.order_type."
 )
 def order(
     model: type[Model],

--- a/tests/test_legacy_order.py
+++ b/tests/test_legacy_order.py
@@ -92,7 +92,7 @@ def test_legacy_order_argument_is_deprecated():
         assert issubclass(w[-1].category, DeprecationWarning)
         assert (
             str(w[-1].message)
-            == "strawberry_django.order is deprecated in favor of strawberry_django.ordering."
+            == "strawberry_django.order is deprecated in favor of strawberry_django.order_type."
         )
 
 
@@ -108,7 +108,7 @@ def test_legacy_order_type_is_deprecated():
         assert issubclass(w[-1].category, DeprecationWarning)
         assert (
             str(w[-1].message)
-            == "strawberry_django.order is deprecated in favor of strawberry_django.ordering."
+            == "strawberry_django.order is deprecated in favor of strawberry_django.order_type."
         )
 
 


### PR DESCRIPTION
Changed the suggestion to the correct name (`order_type` instead of `ordering`)

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document. (A long time ago, my apologies if I'm missing something.)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Update deprecation suggestion to reference `order_type` instead of `ordering`