### PR TITLE
fix: fix debug toolbar integration to work with v6.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -222,14 +222,14 @@ typing_extensions = ">=4.0.0"
 
 [[package]]
 name = "django-debug-toolbar"
-version = "4.4.6"
+version = "6.0.0"
 description = "A configurable set of panels that display various debug information about the current request/response."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "django_debug_toolbar-4.4.6-py3-none-any.whl", hash = "sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45"},
-    {file = "django_debug_toolbar-4.4.6.tar.gz", hash = "sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044"},
+    {file = "django_debug_toolbar-6.0.0-py3-none-any.whl", hash = "sha256:0cf2cac5c307b77d6e143c914e5c6592df53ffe34642d93929e5ef095ae56841"},
+    {file = "django_debug_toolbar-6.0.0.tar.gz", hash = "sha256:6eb9fa6f4a5884bf04004700ffb5a44043f1fff38784447fc52c1633448c8c14"},
 ]
 
 [package.dependencies]
@@ -1098,4 +1098,4 @@ enum = ["django-choices-field"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "810ea33ded3d25e5238bf66233dfef4737636d56a569824b94386b4797df9f0c"
+content-hash = "89596bf619b611dd68b376a2e827f197dbe04382b2ea45131f5556178468cf91"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,13 @@ python = ">=3.10,<4.0"
 django = ">=4.2"
 asgiref = ">=3.8"
 django-choices-field = { version = ">=2.2.2", optional = true }
-django-debug-toolbar = { version = ">=3.4", optional = true }
+django-debug-toolbar = { version = ">=6.0.0", optional = true }
 strawberry-graphql = ">=0.283.2"
 
 [tool.poetry.group.dev.dependencies]
 channels = { version = ">=3.0.5" }
 django-choices-field = "^2.2.2"
-django-debug-toolbar = "^4.4.6"
+django-debug-toolbar = "^6.0.0"
 django-guardian = "^2.4.0"
 django-types = "^0.22.0"
 factory-boy = "^3.2.1"

--- a/strawberry_django/templates/strawberry_django/debug_toolbar.html
+++ b/strawberry_django/templates/strawberry_django/debug_toolbar.html
@@ -26,7 +26,7 @@
             .querySelector("small").textContent = panel.subtitle;
         }
       });
-      djDebug.setAttribute("data-store-id", data.debugToolbar.storeId);
+      djDebug.setAttribute("data-request-id", data.debugToolbar.requestId);
 
       delete data.debugToolbar;
       return data;

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     "strawberry_django",
 ]
 
+STATIC_URL = "/static/"
 
 ROOT_URLCONF = "tests.urls"
 


### PR DESCRIPTION
Fix #783

## Summary by Sourcery

Fix integration with django-debug-toolbar v6.0 by refactoring the middleware and payload handling, updating dependencies, and adjusting the template to use the new requestId API.

Bug Fixes:
- Restore debug toolbar support for v6.0 by updating payload keys and middleware behavior

Enhancements:
- Bump django-debug-toolbar dependency to >=6.0.0
- Refactor DebugToolbarMiddleware to remove legacy monkey-patches and adopt process_view/_postprocess hooks
- Simplify payload retrieval to use DebugToolbar.request_id instead of store_id

Tests:
- Add STATIC_URL setting for test configuration