### PR TITLE
fix: fix broken future annotations with the new | syntax

### DIFF
--- a/strawberry_django/arguments.py
+++ b/strawberry_django/arguments.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from strawberry import UNSET
 from strawberry.annotation import StrawberryAnnotation
 from strawberry.types.arguments import StrawberryArgument
@@ -15,7 +17,7 @@ def argument(
     if is_list:
         argument_type = list[type_]
     if is_optional:
-        argument_type = type_ | None
+        argument_type = Optional[type_]  # noqa: UP045
 
     return StrawberryArgument(
         default=default,

--- a/strawberry_django/mutations/fields.py
+++ b/strawberry_django/mutations/fields.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import functools
 import inspect
-import operator
-from typing import TYPE_CHECKING, Annotated, Any, TypeVar
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar, Union
 
 import strawberry
 from django.core.exceptions import (
@@ -142,11 +140,11 @@ class DjangoMutationBase(StrawberryDjangoFieldBase):
         if self.handle_errors and not self._resolved_return_type:
             types_ = tuple(get_possible_types(resolved))
             if OperationInfo not in types_:
-                types_ = functools.reduce(operator.__or__, (*types_, OperationInfo))
+                types_ = (*types_, OperationInfo)
 
                 name = capitalize_first(to_camel_case(self.python_name))
                 resolved = Annotated[
-                    types_,
+                    Union[types_],  # noqa: UP007
                     strawberry.union(f"{name}Payload"),
                 ]
                 self.type_annotation = StrawberryAnnotation(

--- a/strawberry_django/ordering.py
+++ b/strawberry_django/ordering.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    Optional,
     TypeVar,
     cast,
     get_origin,
@@ -397,7 +398,7 @@ def order_type(
             if is_auto(type_):
                 type_ = Ordering  # noqa: PLW2901
 
-            cls.__annotations__[fname] = type_ | None
+            cls.__annotations__[fname] = Optional[type_]  # noqa: UP045
 
             field_ = cls.__dict__.get(fname)
             if not isinstance(field_, StrawberryField):
@@ -437,7 +438,7 @@ def order(
             if is_auto(type_):
                 type_ = Ordering  # noqa: PLW2901
 
-            cls.__annotations__[fname] = type_ | None
+            cls.__annotations__[fname] = Optional[type_]  # noqa: UP045
 
             field_ = cls.__dict__.get(fname)
             if not isinstance(field_, StrawberryField):

--- a/tests/test_legacy_order.py
+++ b/tests/test_legacy_order.py
@@ -52,7 +52,7 @@ class FruitOrder:
     color_id: auto
     name: auto
     sweetness: auto
-    color: ColorOrder | None
+    color: "ColorOrder | None"
 
     @strawberry_django.order_field
     def types_number(self, queryset, prefix, value: auto):


### PR DESCRIPTION
## Summary by Sourcery

Fix incompatibilities with future annotations by replacing PEP 604 union syntax in type annotations with typing.Optional and typing.Union constructs, and update related tests.

Bug Fixes:
- Replace occurrences of `type_ | None` with `Optional[type_]` in ordering and arguments modules to avoid broken future annotations
- Wrap unioned types in `Union[...]` instead of PEP 604 tuples in mutation field resolution to ensure correct type annotation
- Update legacy order test to use a string-based forward reference for `ColorOrder | None`

Enhancements:
- Simplify concatenation of possible types tuple by appending `OperationInfo` directly instead of reducing with `operator.__or__`

Tests:
- Adjust test to declare forward-referenced optional type as a string literal

Fix #799