### PR TITLE
fix: docs

### DIFF
--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -183,7 +183,7 @@ class FruitOrder:
 
 @strawberry.type
 class Query:
-    @strawberry_django.offset_paginated(OffsetPaginated[Fruit], order=order)
+    @strawberry_django.offset_paginated(OffsetPaginated[Fruit], order=FruitOrder)
     def fruits(self, only_available: bool = True) -> QuerySet[Fruit]:
         queryset = models.Fruit.objects.all()
         if only_available:


### PR DESCRIPTION
I found a bug at strawberry django pagination page. Name 'order' is not definded here. So i think we should use FruitOrder here.

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

*

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My code follows the code style of this project.
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Bug Fixes:
- Fix undefined name 'order' in the pagination guide by replacing it with FruitOrder

## Summary by Sourcery

Fix undefined 'order' reference in pagination guide example by replacing it with the defined FruitOrder enum

Bug Fixes:
- Replace undefined variable 'order' with FruitOrder in the offset_paginated decorator

Documentation:
- Update pagination guide documentation to correctly reference FruitOrder