### PR TITLE
feat: add support for strawberry.Maybe type in mutations and filter processing

### DIFF
--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -268,6 +268,7 @@ class FruitFilter:
 >
 > - `value` parameter of type `relay.GlobalID` is resolved to its `node_id` attribute
 > - `value` parameter of type `Enum` is resolved to is's value
+> - `value` parameter wrapped in `strawberry.Some` (from [`Maybe`](https://strawberry.rocks/docs/types/maybe#maybe) type) is unwrapped and resolved
 > - above types are converted in `lists` as well
 >
 > resolution can modified via `strawberry_django.filter_field(resolve_value=...)`

--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -23,7 +23,7 @@ from django.db.models.fields.reverse_related import (
     OneToOneRel,
 )
 from django.utils.functional import LazyObject
-from strawberry import UNSET, relay
+from strawberry import UNSET, Some, relay
 
 from strawberry_django.fields.types import (
     ListInput,
@@ -167,6 +167,9 @@ def parse_input(
     *,
     key_attr: str | None = None,
 ):
+    if isinstance(data, Some):
+        return parse_input(info, data.value, key_attr=key_attr)
+
     if isinstance(data, dict):
         return {k: parse_input(info, v, key_attr=key_attr) for k, v in data.items()}
 

--- a/tests/filters/test_filters_v2.py
+++ b/tests/filters/test_filters_v2.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, cast
 import pytest
 import strawberry
 from django.db.models import Case, Count, Q, QuerySet, Value, When
-from strawberry import auto
+from strawberry import Some, auto
 from strawberry.exceptions import MissingArgumentsAnnotationsError
 from strawberry.relay import GlobalID
 from strawberry.types import ExecutionResult, get_object_definition
@@ -128,6 +128,7 @@ def query():
 @pytest.mark.parametrize(
     ("value", "resolved"),
     [
+        (None, None),
         (2, 2),
         ("something", "something"),
         (GlobalID("", "24"), "24"),
@@ -136,59 +137,22 @@ def query():
             [1, "str", GlobalID("", "24"), Version.THREE],
             [1, "str", "24", Version.THREE.value],
         ),
+        # Some (inner type of Maybe) tests
+        (Some("test_string"), "test_string"),
+        (Some(None), None),
+        (Some(Version.TWO), Version.TWO.value),
+        (Some(GlobalID("FruitNode", "42")), "42"),
+        (Some(Some("nested")), "nested"),
+        (Some(Some(None)), None),
+        (
+            [Some(1), Some("test"), Some(None), Some(Version.ONE)],
+            [1, "test", None, Version.ONE.value],
+        ),
+        ([Some(Some("foo")), Some(None)], ["foo", None]),
     ],
 )
 def test_resolve_value(value, resolved):
     assert resolve_value(value) == resolved
-
-
-def test_resolve_value_maybe():
-    """Test that strawberry.Maybe type is properly handled in resolve_value."""
-    try:
-        from strawberry import Maybe
-    except ImportError:
-        pytest.skip("strawberry.Maybe is not available in this version")
-
-    # Test Maybe with a value
-    maybe_with_value = Maybe(value="test_string")
-    assert resolve_value(maybe_with_value) == "test_string"
-
-    # Test Maybe with None
-    maybe_none = Maybe(value=None)
-    assert resolve_value(maybe_none) is None
-
-    # Test Maybe with nested types
-    maybe_enum = Maybe(value=Version.TWO)
-    assert resolve_value(maybe_enum) == Version.TWO.value
-
-    maybe_gid = Maybe(value=GlobalID("FruitNode", "42"))
-    assert resolve_value(maybe_gid) == "42"
-
-    # Test Maybe with deeply nested None value
-    maybe_deep_none = Maybe(value=Maybe(value=None))
-    assert resolve_value(maybe_deep_none) is None
-
-    # Test Maybe in a list
-    maybe_list = [
-        Maybe(value=1),
-        Maybe(value="test"),
-        Maybe(value=None),
-        Maybe(value=Version.ONE),
-    ]
-    resolved_list = resolve_value(maybe_list)
-    assert resolved_list == [1, "test", None, Version.ONE.value]
-
-    # Test nested Maybe
-    nested_maybe = Maybe(value=Maybe(value="nested"))
-    assert resolve_value(nested_maybe) == "nested"
-
-    # Test list containing nested Maybes
-    nested_maybe_list = [
-        Maybe(value=Maybe(value="foo")),
-        Maybe(value=None),
-    ]
-    resolved_nested_list = resolve_value(nested_maybe_list)
-    assert resolved_nested_list == ["foo", None]
 
 
 def test_filter_field_missing_prefix():
@@ -627,3 +591,120 @@ async def test_async_resolver_filter(fruits):
     assert result.data["fruits"] == [
         {"name": "strawberry"},
     ]
+
+
+def test_resolve_value_some_with_range_lookup():
+    range_lookup = strawberry_django.RangeLookup(
+        start=Some(GlobalID("FruitNode", "10")),
+        end=Some(GlobalID("FruitNode", "20")),
+    )
+    assert resolve_value(range_lookup.start) == "10"
+    assert resolve_value(range_lookup.end) == "20"
+
+
+def test_resolve_value_some_with_comparison_filter_lookup():
+    gid = GlobalID("FruitNode", "125")
+    filter_lookup = strawberry_django.ComparisonFilterLookup(
+        exact=Some(gid),
+        range=strawberry_django.RangeLookup(start=Some(gid), end=Some(gid)),
+    )
+
+    @strawberry_django.filters.filter_type(models.Fruit)
+    class Filter:
+        id: strawberry_django.ComparisonFilterLookup[GlobalID] | None
+
+    filter_: Any = Filter(id=filter_lookup)  # type: ignore[arg-type]
+    object_: Any = object()
+    q = process_filters(filter_, object_, object_)[1]
+    assert q == Q(id__exact="125", id__range=["125", "125"])
+
+
+def test_filter_method_some_value_resolution():
+    received_values: dict[str, Any] = {}
+
+    @strawberry_django.filters.filter_type(models.Fruit)
+    class Filter:
+        @strawberry_django.filter_field(resolve_value=True)
+        def field_filter_resolved(self, value: GlobalID, prefix):
+            received_values["resolved"] = value
+            return Q()
+
+        @strawberry_django.filter_field
+        def field_filter_unset(self, value: GlobalID, prefix):
+            received_values["unset"] = value
+            return Q()
+
+    gid = GlobalID("FruitNode", "125")
+    filter_: Any = Filter(
+        field_filter_resolved=Some(gid),  # type: ignore[arg-type]
+        field_filter_unset=Some(gid),  # type: ignore[arg-type]
+    )
+    object_: Any = object()
+    process_filters(filter_, object_, object_)
+
+    assert isinstance(received_values["resolved"], str)
+    assert received_values["resolved"] == "125"
+    # When resolve_value is UNSET for filter methods, Some wrapper is kept
+    assert isinstance(received_values["unset"], Some)
+    assert received_values["unset"].value == gid
+
+
+def test_filter_with_some_enum_value():
+    filter_lookup = strawberry_django.ComparisonFilterLookup(
+        exact=Some(Version.TWO),
+    )
+    assert resolve_value(filter_lookup.exact) == "second"
+
+
+def test_filter_with_some_in_list():
+    filter_lookup = strawberry_django.BaseFilterLookup(
+        in_list=[Some(GlobalID("FruitNode", "1")), Some(GlobalID("FruitNode", "2"))],
+    )
+    resolved = resolve_value(filter_lookup.in_list)
+    assert resolved == ["1", "2"]
+
+
+def test_filter_with_nested_some():
+    nested = Some(Some(Some(GlobalID("FruitNode", "42"))))
+    assert resolve_value(nested) == "42"
+
+
+def test_filter_with_some_none():
+    assert resolve_value(Some(None)) is None
+    assert resolve_value(Some(Some(None))) is None
+
+
+def test_process_filters_with_some_wrapped_values():
+    @strawberry_django.filters.filter_type(models.Fruit)
+    class Filter:
+        name: strawberry_django.FilterLookup[str] | None
+
+    name_lookup = strawberry_django.FilterLookup(
+        exact=Some("strawberry"),
+        contains=Some("berry"),
+    )
+    filter_: Any = Filter(name=name_lookup)  # type: ignore[arg-type]
+    object_: Any = object()
+    _, q = process_filters(filter_, object_, object_)
+    assert set(q.children) == {
+        ("name__exact", "strawberry"),
+        ("name__contains", "berry"),
+    }
+
+
+def test_process_filters_with_some_global_id_in_lookup():
+    @strawberry_django.filters.filter_type(models.Fruit)
+    class Filter:
+        id: strawberry_django.BaseFilterLookup[GlobalID] | None
+
+    id_lookup = strawberry_django.BaseFilterLookup(
+        exact=Some(GlobalID("FruitNode", "42")),
+        in_list=[
+            Some(GlobalID("FruitNode", "1")),
+            Some(GlobalID("FruitNode", "2")),
+        ],
+    )
+    filter_: Any = Filter(id=id_lookup)  # type: ignore[arg-type]
+    object_: Any = object()
+    _, q = process_filters(filter_, object_, object_)
+    assert dict(q.children) == {"id__exact": "42", "id__in": ["1", "2"]}

--- a/tests/mutations/test_mutations.py
+++ b/tests/mutations/test_mutations.py
@@ -521,3 +521,24 @@ def test_update_geo(mutation):
     assert deep_tuple_to_list(geofield_obj.multi_point.tuple) == multi_point
     assert deep_tuple_to_list(geofield_obj.multi_line_string.tuple) == multi_line_string
     assert deep_tuple_to_list(geofield_obj.multi_polygon.tuple) == multi_polygon
+
+
+def test_parse_input_unwraps_some():
+    from enum import Enum
+    from typing import Any
+
+    from strawberry import Some
+
+    from strawberry_django.mutations.resolvers import parse_input
+
+    class Color(Enum):
+        RED = "red"
+        GREEN = "green"
+
+    info: Any = None
+    assert parse_input(info, Some("hello")) == "hello"
+    assert parse_input(info, Some(None)) is None
+    assert parse_input(info, Some(Some("nested"))) == "nested"
+    assert parse_input(info, Some(Color.RED)) == "red"
+    assert parse_input(info, [Some("a"), Some("b")]) == ["a", "b"]
+    assert parse_input(info, {"key": Some("value")}) == {"key": "value"}


### PR DESCRIPTION
## Description

This PR adds support for the `strawberry.Maybe` type in the Django filter processing code, addressing issue #753.

## Changes

- Updated `resolve_value()` function in `strawberry_django/filters.py` to detect and handle `strawberry.Maybe` instances
- Added comprehensive test coverage for Maybe type support in `tests/filters/test_filters_v2.py`

## Testing

- [x] All existing tests pass
- [x] New tests for Maybe type pass
- [x] Tests gracefully skip if Maybe is not available in strawberry version

## Notes

- The implementation gracefully handles cases where `strawberry.Maybe` is not available in the installed version
- Maybe values are recursively resolved to handle nested cases
- Supports Maybe instances in lists

Closes #753

## Summary by Sourcery

Enable filter processing to recognize and unwrap strawberry.Maybe values by extracting and resolving their .value, with added test coverage for various Maybe scenarios.

New Features:
- Add support for strawberry.Maybe type in filter resolve_value to unwrap Maybe instances

Enhancements:
- Recursively resolve nested Maybe values and handle lists of Maybe instances
- Gracefully skip Maybe handling when strawberry.Maybe is unavailable

Tests:
- Add tests for strawberry.Maybe handling including value present, None, nested, and list cases