### PR TITLE
feat: make messages if there's assert_no_errors more verbose

### DIFF
--- a/strawberry_django/test/client.py
+++ b/strawberry_django/test/client.py
@@ -91,7 +91,7 @@ class AsyncTestClient(TestClient):
             assert_no_errors if asserts_errors is None else asserts_errors
         )
         if assert_no_errors:
-            assert response.errors is None
+            assert response.errors is None, response.errors
 
         return response
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,46 @@
+import pytest
+from django.test.client import Client
+
+from strawberry_django.test.client import AsyncTestClient
+from tests.utils import GraphQLTestClient
+
+query_to_non_existed_field = "{ nonExistentField { id } }"
+
+
+def check_non_existed_field_error(errors):
+    assert isinstance(errors, list)
+    assert len(errors) == 1
+    error = errors[0]
+    assert isinstance(error, dict)
+    assert "nonExistentField" in error["message"]
+    assert "Cannot query field" in error["message"]
+    assert error["locations"]
+
+
+def test_client_assert_no_errors_verbose_message(db):
+    """Test that GraphQLTestClient (sync) raises AssertionError with verbose error messages.
+
+    This test directly uses GraphQLTestClient with a sync Client to verify the verbose
+    error message functionality in the sync client implementation.
+    """
+    client = GraphQLTestClient("/graphql/", Client())
+
+    with pytest.raises(AssertionError) as exc_info:
+        client.query(query_to_non_existed_field)
+
+    check_non_existed_field_error(exc_info.value.args[0])
+
+
+@pytest.mark.asyncio
+async def test_async_client_assert_no_errors_verbose_message(db):
+    """Test that AsyncTestClient raises AssertionError with verbose error messages.
+
+    This test directly uses AsyncTestClient to verify the verbose error message
+    functionality in the async client implementation.
+    """
+    client = AsyncTestClient("/graphql_async/")
+
+    with pytest.raises(AssertionError) as exc_info:
+        await client.query(query_to_non_existed_field)
+
+    check_non_existed_field_error(exc_info.value.args[0])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -206,6 +206,6 @@ class GraphQLTestClient(TestClient):
             assert_no_errors if asserts_errors is None else asserts_errors
         )
         if assert_no_errors:
-            assert response.errors is None
+            assert response.errors is None, response.errors
 
         return response


### PR DESCRIPTION
## Description

At test client if there `assert_no_errors`(default behavior) then displayed just that assert not passed, but no messages. Those changes fix that behavior and will expose `response.errors`

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Enhancements:
- Include the GraphQL response errors in assertion failures when assert_no_errors is enabled in the Strawberry Django test client and test utilities.