### PR TITLE
feat: use the new type-friendly way to define scalars from Strawberry

### DIFF
--- a/docs/integrations/geodjango.md
+++ b/docs/integrations/geodjango.md
@@ -38,6 +38,7 @@ class Location(models.Model):
 # types.py
 import strawberry_django
 from strawberry import auto
+from django.contrib.gis.geos import Point, Polygon
 
 from . import models
 
@@ -53,6 +54,14 @@ class LocationInput:
     name: auto
     point: auto
     area: auto
+
+# You can also use geos types directly in annotations
+@strawberry_django.type(models.Location)
+class LocationExplicit:
+    id: auto
+    name: auto
+    point: Point
+    area: Polygon | None
 ```
 
 ## GraphQL Data Format

--- a/poetry.lock
+++ b/poetry.lock
@@ -421,21 +421,6 @@ files = [
 ]
 
 [[package]]
-name = "lia-web"
-version = "0.3.1"
-description = "This package has been renamed to cross-web. Install cross-web instead."
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "lia_web-0.3.1-py3-none-any.whl", hash = "sha256:e4e6e7a9381e228aca60a6f3d67dbae9a5f4638eced242d931f95797ddba3f8b"},
-    {file = "lia_web-0.3.1.tar.gz", hash = "sha256:7f551269eddd729f1437e9341ad21622a849eb0c0975d9232ccbbaadbdc74c06"},
-]
-
-[package.dependencies]
-cross-web = ">=0.3.0"
-
-[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
@@ -926,19 +911,19 @@ doc = ["sphinx"]
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.287.3"
+version = "0.288.0"
 description = "A library for creating GraphQL APIs"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "strawberry_graphql-0.287.3-py3-none-any.whl", hash = "sha256:2bb1f9b122ef1213f82f01cf27a095eb0776fda78e12af9e60c54de6e543797c"},
-    {file = "strawberry_graphql-0.287.3.tar.gz", hash = "sha256:c81126cc75102aa32417048f074429d6c5c8d096424aa939fdb8827b8c5f84a9"},
+    {file = "strawberry_graphql-0.288.0-py3-none-any.whl", hash = "sha256:19b07b3201f23a68880f63883d3e47d699b5ac4de93ccdad35c76fd93ba2392d"},
+    {file = "strawberry_graphql-0.288.0.tar.gz", hash = "sha256:10fd113fe595a477ded8f8a39bcd49e8ec84f1cda70dac1369590692c028b09e"},
 ]
 
 [package.dependencies]
+cross-web = ">=0.4.0"
 graphql-core = ">=3.2.0,<3.4.0"
-lia-web = ">=0.2.1"
 packaging = ">=23"
 python-dateutil = ">=2.7"
 typing-extensions = ">=4.5.0"
@@ -1101,4 +1086,4 @@ enum = ["django-choices-field"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "5d30bf45d25c9e4dbd996a62c7807f159a0374177dccd3ef3390d782f8d9d074"
+content-hash = "ec18499ac1e234cfdb37635b0b0cf70259f4d381bcdaf27daa9170f66c6c821b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ django = ">=4.2"
 asgiref = ">=3.8"
 django-choices-field = { version = ">=2.2.2", optional = true }
 django-debug-toolbar = { version = ">=6.0.0", optional = true }
-strawberry-graphql = ">=0.286.0"
+strawberry-graphql = ">=0.288.0"
 
 [tool.poetry.group.dev.dependencies]
 channels = { version = ">=3.0.5" }


### PR DESCRIPTION
Updating scalars to use the new type-friendly way of defining them: https://github.com/strawberry-graphql/strawberry/releases/tag/0.288.0

## Summary by Sourcery

Adopt Strawberry's new type-friendly scalar registration for Django GIS geometry types and update type mappings accordingly.

New Features:
- Register Django GIS geometry classes directly as Strawberry scalars using the new scalar definition API.

Enhancements:
- Preserve backwards-compatible aliases to Django GEOS geometry classes while integrating with Strawberry's default scalar registry.
- Relax field-to-GraphQL type maps to accept either types or factory functions for GraphQL field resolution.

Build:
- Bump the strawberry-graphql dependency to version 0.288.0 or newer to support the new scalar definition approach.