### PR TITLE
Autopub release testing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-Release type: minor
+Release type: patch
 
 Nothing changed, testing the new release process using `autopub`.

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -56,8 +56,6 @@ from .fields.field import field as _field
 from .fields.types import get_model_field, resolve_model_field_name
 from .settings import strawberry_django_settings as django_settings
 
-# To be removed comment.
-
 __all__ = [
     "StrawberryDjangoDefinition",
     "input",


### PR DESCRIPTION
Final autopub testing release

## Summary by Sourcery

Adjust release metadata for autopub testing and remove an obsolete comment.

Chores:
- Update release notes to mark this as a patch release for autopub testing.
- Clean up an obsolete comment in the Django type module.