### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,9 +31,9 @@ jobs:
         id: check
         run: |
           if uvx --from autopub==1.0.0a51 --with pygithub autopub check; then
-            echo "has_release=true" >> $GITHUB_OUTPUT
+            echo "has_release=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_release=false" >> $GITHUB_OUTPUT
+            echo "has_release=false" >> "$GITHUB_OUTPUT"
             if [ "${{ github.event_name }}" = "pull_request_target" ]; then
               exit 1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
         id: check
         run: |
            if uvx --from autopub==1.0.0a51 --with pygithub autopub check; then
-             echo "has_release=true" >> $GITHUB_OUTPUT
+             echo "has_release=true" >> "$GITHUB_OUTPUT"
            else
-             echo "has_release=false" >> $GITHUB_OUTPUT
+             echo "has_release=false" >> "$GITHUB_OUTPUT"
              if [ "${{ github.event_name }}" = "pull_request" ]; then
                exit 1
              fi


### PR DESCRIPTION
## Summary by Sourcery

Separate release checks for pushes and pull requests and harden the AutoPub-based release workflow.

New Features:
- Introduce a dedicated pull_request_target workflow to run AutoPub release checks and upload .autopub artifacts for PRs.

Enhancements:
- Simplify and rename the main release workflow to run only on main pushes with clearer job names and debug logging.
- Pin AutoPub invocation via uvx directly in workflow steps instead of relying on a shared environment variable.
- Verify the presence of the .autopub directory before proceeding with release artifacts and publishing.

CI:
- Adjust release workflow triggers to run on main branch pushes only and add a separate PR workflow for release validation.

Chores:
- Update GitHub token usage in workflows to rely on a dedicated BOT_TOKEN secret for AutoPub operations.