### PR TITLE
chore: db unique key optimization

### DIFF
--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -302,6 +302,30 @@ def get_total_count(queryset: QuerySet) -> int:
                     RuntimeWarning,
                     stacklevel=2,
                 )
+                queryset = remove_window_pagination(queryset)
+                return queryset.count()
+        else:
+            # Check if window pagination might have filtered out existing results
+            # Look for filters that could hide results (offset > 0 or restrictive limits)
+            has_restrictive_pagination = any(
+                hasattr(child, "lhs")
+                and isinstance(child.lhs, _PaginationWindow)
+                and (
+                    # Check for offset filters: _strawberry_row_number > offset (where offset > 0)
+                    (hasattr(child, "lookup_name") and child.lookup_name == "gt")
+                    or
+                    # Check for limit filters that might be restrictive
+                    (hasattr(child, "lookup_name") and child.lookup_name == "lte")
+                )
+                for child in queryset.query.where.children
+            )
+
+            if has_restrictive_pagination:
+                # Might have filtered out existing results, need to count
+                queryset = remove_window_pagination(queryset)
+                return queryset.count()
+
+        return 0
 
         # If we have no results, we can't get the total count from the cache.
         # In this case we will remove the pagination filter to be able to `.count()`


### PR DESCRIPTION
=

## Summary by Sourcery

Optimize queryset pagination and ensure required unique key fields are always selected in database queries.

Enhancements:
- Adjust connection pagination limits to avoid unnecessary result caps when expected results equal the configured maximum.
- Always include the `db_unique_key` field in `.only()` query projections to prevent refetching and N+1 issues.
- Improve total count handling for window-paginated querysets by detecting restrictive pagination filters and recomputing counts when needed.