### PR TITLE
feat: implement pagination max limit setting

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,19 @@
+---
+release type: minor
+---
+
+Add configurable `PAGINATION_MAX_LIMIT` setting to cap pagination requests, preventing clients from requesting unlimited data via `limit: null` or excessive limits.
+
+This addresses security and performance concerns by allowing projects to enforce a maximum number of records that can be requested through pagination.
+
+**Configuration:**
+
+```python
+STRAWBERRY_DJANGO = {
+    "PAGINATION_MAX_LIMIT": 1000,  # Cap all requests to 1000 records
+}
+```
+
+When set, any client request with `limit: null`, negative limits, or limits exceeding the configured maximum will be capped to `PAGINATION_MAX_LIMIT`. Defaults to `None` (unlimited) for backward compatibility, though setting a limit is recommended for production environments.
+
+Works with both offset-based and window-based pagination.

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -69,6 +69,27 @@ The default limit for pagination is set to `100`. This can be changed in the
 [strawberry django settings](./settings.md) to increase or decrease that number,
 or even set to `None` to set it to unlimited.
 
+### Maximum limit for pagination
+
+To prevent clients from requesting too many records at once (which could cause performance
+issues), you can configure a maximum limit using the `PAGINATION_MAX_LIMIT` setting.
+When set, this will cap any limit value requested by clients, including `None` (unlimited) requests.
+
+For example, if you set `PAGINATION_MAX_LIMIT` to `1000`, a client requesting `limit: 5000`
+or `limit: null` will only receive a maximum of 1000 records.
+
+```python title="settings.py"
+STRAWBERRY_DJANGO = {
+    "PAGINATION_DEFAULT_LIMIT": 100,
+    "PAGINATION_MAX_LIMIT": 1000,  # Cap all pagination requests at 1000 records
+}
+```
+
+By default, `PAGINATION_MAX_LIMIT` is set to `None`, which means unlimited requests are allowed.
+This maintains backward compatibility but is not recommended for production environments.
+
+### Custom pagination limits per field
+
 To configure it on a per field basis, you can define your own `OffsetPaginationInput`
 subclass and modify its default value, like:
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -66,6 +66,12 @@ A dictionary with the following optional keys:
 
       Default limit for [pagination](pagination.md) when one is not provided by the client. Can be set to `None` to set it to unlimited.
 
+- **`PAGINATION_MAX_LIMIT`** (default: `None`)
+
+      Maximum limit for [pagination](pagination.md) that can be requested by clients. When set, this will cap any limit value requested
+      by clients, including `None` (unlimited) requests. This is useful to prevent clients from requesting too many records at once,
+      which could cause performance issues. Can be set to `None` to allow unlimited requests (not recommended for production).
+
 - **`ALLOW_MUTATIONS_WITHOUT_FILTERS`** (default: `False`)
 
       If True, [CUD mutations](mutations.md#cud-mutations) will not require a filter to be specified.
@@ -83,6 +89,7 @@ STRAWBERRY_DJANGO = {
     "MAP_AUTO_ID_AS_GLOBAL_ID": True,
     "DEFAULT_PK_FIELD_NAME": "id",
     "PAGINATION_DEFAULT_LIMIT": 250,
+    "PAGINATION_MAX_LIMIT": 1000,
     "ALLOW_MUTATIONS_WITHOUT_FILTERS": True,
 }
 ```

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -143,9 +143,20 @@ def apply(
     else:
         start = pagination.offset
         limit = pagination.limit
+        settings = strawberry_django_settings()
+
         if limit is UNSET:
-            settings = strawberry_django_settings()
             limit = settings["PAGINATION_DEFAULT_LIMIT"]
+
+        # Apply max limit if configured
+        max_limit = settings["PAGINATION_MAX_LIMIT"]
+        if max_limit is not None:
+            if max_limit < 0:
+                raise ValueError(
+                    f"PAGINATION_MAX_LIMIT must be non-negative, got {max_limit}"
+                )
+            if limit is None or limit < 0 or limit > max_limit:
+                limit = max_limit
 
         if limit is not None and limit >= 0:
             stop = start + limit
@@ -197,6 +208,17 @@ def apply_window_pagination(
             if max_results is not None
             else settings["PAGINATION_DEFAULT_LIMIT"]
         )
+
+    # Apply max limit if configured
+    settings = strawberry_django_settings()
+    max_limit = settings["PAGINATION_MAX_LIMIT"]
+    if max_limit is not None:
+        if max_limit < 0:
+            raise ValueError(
+                f"PAGINATION_MAX_LIMIT must be non-negative, got {max_limit}"
+            )
+        if limit is None or limit < 0 or limit > max_limit:
+            limit = max_limit
 
     order_by = [
         expr

--- a/strawberry_django/settings.py
+++ b/strawberry_django/settings.py
@@ -46,6 +46,11 @@ class StrawberryDjangoSettings(TypedDict):
     #: to set it to unlimited.
     PAGINATION_DEFAULT_LIMIT: int | None
 
+    #: The maximum limit for pagination that can be requested by clients.
+    #: If set, this will cap any limit value (including None/unlimited requests).
+    #: Can be set to `None` to allow unlimited requests (not recommended).
+    PAGINATION_MAX_LIMIT: int | None
+
     #: If True, filters used in mutations can be omitted
     ALLOW_MUTATIONS_WITHOUT_FILTERS: bool
 
@@ -60,6 +65,7 @@ DEFAULT_DJANGO_SETTINGS = StrawberryDjangoSettings(
     DEFAULT_PK_FIELD_NAME="pk",
     USE_DEPRECATED_FILTERS=False,
     PAGINATION_DEFAULT_LIMIT=100,
+    PAGINATION_MAX_LIMIT=None,
     ALLOW_MUTATIONS_WITHOUT_FILTERS=False,
 )
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -31,6 +31,7 @@ def test_non_defaults():
             DEFAULT_PK_FIELD_NAME="id",
             USE_DEPRECATED_FILTERS=True,
             PAGINATION_DEFAULT_LIMIT=250,
+            PAGINATION_MAX_LIMIT=1_000,
             ALLOW_MUTATIONS_WITHOUT_FILTERS=True,
         ),
     ):
@@ -46,6 +47,7 @@ def test_non_defaults():
                 DEFAULT_PK_FIELD_NAME="id",
                 USE_DEPRECATED_FILTERS=True,
                 PAGINATION_DEFAULT_LIMIT=250,
+                PAGINATION_MAX_LIMIT=1_000,
                 ALLOW_MUTATIONS_WITHOUT_FILTERS=True,
             )
         )


### PR DESCRIPTION
Fix #846

## Summary by Sourcery

Introduce a configurable maximum pagination limit and ensure it is enforced across offset and window pagination.

New Features:
- Add PAGINATION_MAX_LIMIT setting to cap the number of records clients can request via pagination.
- Support maximum pagination limits in both offset-based and window-based pagination helpers.

Enhancements:
- Document the new PAGINATION_MAX_LIMIT setting and its usage in the pagination and settings guides.

Tests:
- Add test coverage to verify PAGINATION_MAX_LIMIT behavior for various requested limits in offset and window pagination.