### PR TITLE
fix: sync pageInfo.limit with effective pagination limit

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,39 @@
+---
+release type: patch
+---
+
+Pagination `pageInfo.limit` now returns the actual limit applied (after defaults and max caps), not the raw request value.
+
+For example, with `PAGINATION_DEFAULT_LIMIT=20`, `PAGINATION_MAX_LIMIT=50`:
+
+```graphql
+{ fruits(pagination: { limit: null }) { pageInfo { limit } } }
+```
+
+Before:
+```json
+{
+  "data": {
+    "fruits": {
+      "pageInfo": {
+        "limit": null
+      }
+    }
+  }
+}
+```
+
+After:
+```json
+{
+  "data": {
+    "fruits": {
+      "pageInfo": {
+        "limit": 20
+      }
+    }
+  }
+}
+```
+
+Also fixes `limit: null` to use `PAGINATION_DEFAULT_LIMIT` instead of `PAGINATION_MAX_LIMIT`.


### PR DESCRIPTION
Related to #846

## Summary by Sourcery

Align pagination metadata with the effective limit applied and clarify limit handling defaults.

Bug Fixes:
- Ensure pageInfo.limit reflects the effective pagination limit after applying defaults and max caps instead of the raw requested value.
- Treat null pagination limits consistently with unset limits so they use PAGINATION_DEFAULT_LIMIT rather than falling back to PAGINATION_MAX_LIMIT.
- Apply unified limit resolution logic for both offset and window pagination, including handling of negative limits and invalid max limits.

Enhancements:
- Introduce a shared helper to compute the effective pagination limit based on requested, default, and max settings.
- Expand pagination test coverage to cover pageInfo.limit behavior and various combinations of requested, default, and max limits.

Documentation:
- Add a release note documenting the corrected pageInfo.limit behavior and the handling of null limits.