### PR TITLE
feat: add support for graphql-core 3.3.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,9 @@ jobs:
         mode:
           - std
           - geos
+        gql-core:
+          - '3.2'
+          - '3.3'
         exclude:
           # Django 4.2 only supports python 3.8-3.12
           - django-version: 4.2.*
@@ -89,6 +92,13 @@ jobs:
         run: uv sync
       - name: Install Django ${{ matrix.django-version }}
         run: uv pip install "django==${{ matrix.django-version }}"
+      - name: Install graphql-core ${{ matrix.gql-core }}
+        run: |
+          if [ "${{ matrix.gql-core }}" = "3.2" ]; then
+            uv pip install "graphql-core>=3.2.0,<3.3.0"
+          else
+            uv pip install "graphql-core==3.3.0a12"
+          fi
       - name: Test with pytest
         run: uv run --no-sync pytest -n auto --showlocals -vvv --cov-report=xml
       - name: Upload coverage to Codecov

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+---
+release type: minor
+---
+
+Add support for graphql-core 3.3.x alongside existing 3.2.x support.
+
+The minimum supported version of strawberry-graphql has been increased to 0.310.1.
+When using the graphql-core 3.3.x series, the minimum supported version is 3.3.0a12.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Framework :: Django :: 6.0",
 ]
 requires-python = ">=3.10,<4.0"
-dependencies = ["django>=4.2", "asgiref>=3.8", "strawberry-graphql>=0.303.0"]
+dependencies = ["django>=4.2", "asgiref>=3.8", "strawberry-graphql>=0.310.1"]
 
 [project.urls]
 homepage = "https://strawberry.rocks/docs/django"

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -33,7 +33,6 @@ from graphql import (
     GraphQLWrappingType,
     get_argument_values,
 )
-from graphql.execution.collect_fields import collect_sub_fields
 from graphql.language.ast import OperationType
 from graphql.type.definition import GraphQLResolveInfo, get_named_type
 from strawberry import UNSET, relay
@@ -54,6 +53,7 @@ from strawberry_django.relay.list_connection import DjangoListConnection
 from strawberry_django.resolvers import django_fetch
 
 from .descriptors import ModelProperty
+from .utils.gql_compat import get_sub_field_selections
 from .utils.inspect import (
     PrefetchInspector,
     get_model_field,
@@ -710,13 +710,7 @@ def _get_selections(
     info: GraphQLResolveInfo,
     parent_type: GraphQLObjectType | GraphQLInterfaceType,
 ) -> dict[str, list[FieldNode]]:
-    return collect_sub_fields(
-        info.schema,
-        info.fragments,
-        info.variable_values,
-        cast("GraphQLObjectType", parent_type),
-        info.field_nodes,
-    )
+    return get_sub_field_selections(info, parent_type)
 
 
 def _get_field_arguments(node: FieldNode) -> tuple:

--- a/strawberry_django/utils/__init__.py
+++ b/strawberry_django/utils/__init__.py
@@ -1,0 +1,3 @@
+from strawberry_django.utils.gql_compat import IS_GQL_32, IS_GQL_33
+
+__all__ = ["IS_GQL_32", "IS_GQL_33"]

--- a/strawberry_django/utils/gql_compat.py
+++ b/strawberry_django/utils/gql_compat.py
@@ -1,0 +1,73 @@
+"""Compatibility layer for graphql-core 3.2.x and 3.3.x."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from graphql import (
+    FieldNode,
+    GraphQLInterfaceType,
+    GraphQLObjectType,
+)
+from graphql.version import VersionInfo, version_info
+
+if TYPE_CHECKING:
+    from graphql.type.definition import GraphQLResolveInfo
+
+IS_GQL_33 = version_info >= VersionInfo.from_str("3.3.0a0")
+IS_GQL_32 = not IS_GQL_33
+
+
+def get_sub_field_selections(
+    info: GraphQLResolveInfo,
+    parent_type: GraphQLObjectType | GraphQLInterfaceType,
+) -> dict[str, list[FieldNode]]:
+    """Collect sub-fields, handling API differences between 3.2.x and 3.3.x."""
+    if IS_GQL_32:
+        return _get_selections_gql32(info, parent_type)
+    return _get_selections_gql33(info, parent_type)
+
+
+def _get_selections_gql32(
+    info: GraphQLResolveInfo,
+    parent_type: GraphQLObjectType | GraphQLInterfaceType,
+) -> dict[str, list[FieldNode]]:
+    from graphql.execution.collect_fields import (
+        collect_sub_fields,
+    )
+
+    return collect_sub_fields(
+        info.schema,
+        info.fragments,
+        info.variable_values,
+        cast("GraphQLObjectType", parent_type),
+        info.field_nodes,
+    )
+
+
+def _get_selections_gql33(
+    info: GraphQLResolveInfo,
+    parent_type: GraphQLObjectType | GraphQLInterfaceType,
+) -> dict[str, list[FieldNode]]:
+    from graphql.execution.collect_fields import (
+        FieldDetails,  # type: ignore
+        collect_subfields,  # type: ignore
+    )
+
+    field_group: list[Any] = [
+        FieldDetails(node=fn, defer_usage=None) for fn in info.field_nodes
+    ]
+
+    collected = collect_subfields(
+        info.schema,
+        info.fragments,
+        info.variable_values,
+        info.operation,
+        cast("GraphQLObjectType", parent_type),
+        field_group,
+    )
+
+    return {
+        key: [fd.node for fd in field_details]
+        for key, field_details in collected.grouped_field_set.items()
+    }

--- a/tests/projects/test_schema.py
+++ b/tests/projects/test_schema.py
@@ -5,6 +5,7 @@ from pytest_snapshot.plugin import Snapshot
 
 import strawberry_django
 from strawberry_django import mutations
+from tests.conftest import normalize_sdl
 
 from .models import Issue, Milestone, Project
 from .schema import IssueInput, IssueType, MilestoneType, ProjectType, schema
@@ -14,7 +15,7 @@ SNAPSHOTS_DIR = pathlib.Path(__file__).parent / "snapshots"
 
 def test_schema(snapshot: Snapshot):
     snapshot.snapshot_dir = SNAPSHOTS_DIR
-    snapshot.assert_match(str(schema), "schema.gql")
+    snapshot.assert_match(normalize_sdl(str(schema)), "schema.gql")
 
 
 def test_schema_with_inheritance(snapshot: Snapshot):
@@ -42,4 +43,4 @@ def test_schema_with_inheritance(snapshot: Snapshot):
 
     schema = strawberry.Schema(query=Query, mutation=Mutation)
     snapshot.snapshot_dir = SNAPSHOTS_DIR
-    snapshot.assert_match(str(schema), "schema_with_inheritance.gql")
+    snapshot.assert_match(normalize_sdl(str(schema)), "schema_with_inheritance.gql")

--- a/tests/relay/lazy/test_lazy_annotations.py
+++ b/tests/relay/lazy/test_lazy_annotations.py
@@ -5,6 +5,7 @@ from pytest_snapshot.plugin import Snapshot
 
 import strawberry_django
 from strawberry_django.relay import DjangoListConnection
+from tests.conftest import normalize_sdl
 
 from .a import AuthorConnection, AuthorType
 from .b import BookConnection, BookType
@@ -21,4 +22,4 @@ def test_lazy_type_annotations_in_schema(snapshot: Snapshot):
         authors_conn2: DjangoListConnection[AuthorType] = strawberry_django.connection()
 
     schema = strawberry.Schema(query=Query)
-    snapshot.assert_match(str(schema), "authors_and_books_schema.gql")
+    snapshot.assert_match(normalize_sdl(str(schema)), "authors_and_books_schema.gql")

--- a/tests/relay/test_schema.py
+++ b/tests/relay/test_schema.py
@@ -2,6 +2,8 @@ import pathlib
 
 from pytest_snapshot.plugin import Snapshot
 
+from tests.conftest import normalize_sdl
+
 from .schema import schema
 
 SNAPSHOTS_DIR = pathlib.Path(__file__).parent / "snapshots"
@@ -9,4 +11,4 @@ SNAPSHOTS_DIR = pathlib.Path(__file__).parent / "snapshots"
 
 def test_schema(snapshot: Snapshot):
     snapshot.snapshot_dir = SNAPSHOTS_DIR
-    snapshot.assert_match(str(schema), "schema.gql")
+    snapshot.assert_match(normalize_sdl(str(schema)), "schema.gql")

--- a/tests/relay/treenode/test_lazy_annotations.py
+++ b/tests/relay/treenode/test_lazy_annotations.py
@@ -5,6 +5,7 @@ from pytest_snapshot.plugin import Snapshot
 
 import strawberry_django
 from strawberry_django.relay import DjangoListConnection
+from tests.conftest import normalize_sdl
 
 from .a import TreeNodeAuthorConnection, TreeNodeAuthorType
 from .b import TreeNodeBookConnection, TreeNodeBookType
@@ -25,4 +26,4 @@ def test_lazy_type_annotations_in_schema(snapshot: Snapshot):
         )
 
     schema = strawberry.Schema(query=Query)
-    snapshot.assert_match(str(schema), "authors_and_books_schema.gql")
+    snapshot.assert_match(normalize_sdl(str(schema)), "authors_and_books_schema.gql")


### PR DESCRIPTION
## Summary by Sourcery

Add compatibility with graphql-core 3.3.x while retaining support for 3.2.x and update tooling accordingly.

New Features:
- Support graphql-core 3.3.x in the optimizer field selection logic.

Enhancements:
- Introduce version detection utilities for graphql-core to conditionally adapt behavior.
- Add pytest helpers to skip tests based on the installed graphql-core major.minor version.
- Expand CI test matrix to run against both graphql-core 3.2.x and 3.3.x.
- Update the ruff pre-commit hook to a newer version.