### PR TITLE
fix: suggest using StrFilterLookup instead of FilterLookup[str]

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+---
+release type: patch
+---
+
+Fix `DuplicatedTypeName` errors when using `FilterLookup[str]` by:
+
+- Exporting `StrFilterLookup` from the top-level `strawberry_django` module
+- Adding a deprecation warning when using `FilterLookup[str]` or `FilterLookup[uuid.UUID]`
+- Updating documentation to recommend using specific lookup types
+
+Users should migrate from:
+```python
+from strawberry_django import FilterLookup
+
+@strawberry_django.filter_type(models.Fruit)
+class FruitFilter:
+    name: FilterLookup[str] | None
+```
+
+To:
+```python
+from strawberry_django import StrFilterLookup
+
+@strawberry_django.filter_type(models.Fruit)
+class FruitFilter:
+    name: StrFilterLookup | None
+```

--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -148,15 +148,21 @@ input FruitFilter {
 }
 ```
 
-Single-field lookup can be annotated with the `FilterLookup` generic type.
+Single-field lookup can be annotated with the appropriate lookup type for the field.
+Use specific lookup types like `StrFilterLookup` for strings, `ComparisonFilterLookup` for numbers, etc.
 
 ```python title="types.py"
-from strawberry_django import FilterLookup
+from strawberry_django import StrFilterLookup
 
 @strawberry_django.filter_type(models.Fruit)
 class FruitFilter:
-    name: FilterLookup[str]
+    name: StrFilterLookup | None
 ```
+
+> [!WARNING]
+> Avoid using `FilterLookup[str]` directly. Use the specific lookup type (`StrFilterLookup`)
+> instead to prevent `DuplicatedTypeName` errors. See the [Generic Lookup reference](#generic-lookup-reference)
+> for the full list of available lookup types.
 
 ## Filtering over relationships
 
@@ -227,7 +233,7 @@ class FruitFilter:
         self,
         info: Info,
         queryset: QuerySet,
-        value: strawberry_django.FilterLookup[str],
+        value: strawberry_django.StrFilterLookup,
         prefix: str
     ) -> tuple[QuerySet, Q]:
         queryset = queryset.alias(

--- a/strawberry_django/__init__.py
+++ b/strawberry_django/__init__.py
@@ -11,6 +11,7 @@ from .fields.filter_types import (
     DatetimeFilterLookup,
     FilterLookup,
     RangeLookup,
+    StrFilterLookup,
     TimeFilterLookup,
 )
 from .fields.types import (
@@ -52,6 +53,7 @@ __all__ = [
     "OneToOneInput",
     "Ordering",
     "RangeLookup",
+    "StrFilterLookup",
     "TimeFilterLookup",
     "auth",
     "connection",

--- a/strawberry_django/fields/filter_types.py
+++ b/strawberry_django/fields/filter_types.py
@@ -1,7 +1,9 @@
 import datetime
 import decimal
 import uuid
+import warnings
 from typing import (
+    Any,
     Generic,
     TypeVar,
 )
@@ -80,6 +82,16 @@ class FilterLookup(BaseFilterLookup[T]):
     i_regex: T | None = filter_field(
         description=f"Case-insensitive regular expression match. {_SKIP_MSG}"
     )
+
+    def __class_getitem__(cls, item: Any) -> Any:
+        if item is str or item is uuid.UUID:
+            warnings.warn(
+                f"FilterLookup[{item.__name__}] may cause DuplicatedTypeName errors. "
+                "Use StrFilterLookup instead.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return super().__class_getitem__(item)  # type: ignore[misc]
 
 
 @strawberry.input(name="FilterLookup")


### PR DESCRIPTION
Fix #845

## Summary by Sourcery

Deprecate direct use of FilterLookup[str] in favor of StrFilterLookup and update public API, documentation, and tests accordingly.

Enhancements:
- Add a __class_getitem__ deprecation warning when FilterLookup is parameterized with str or uuid.UUID to guide users toward StrFilterLookup.
- Export StrFilterLookup from the top-level strawberry_django package for easier consumption.

Documentation:
- Update filter documentation to recommend using type-specific lookup classes such as StrFilterLookup instead of FilterLookup[str], including a warning about potential DuplicatedTypeName errors and a reference to generic lookup types.

Tests:
- Adjust filter-related tests to use StrFilterLookup instead of FilterLookup[str] to align with the new recommendation.