### PR TITLE
fix: forward args to offset paginated extensions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+---
+release type: patch
+---
+
+Fix offset pagination extensions so they receive pagination, order, and filter
+arguments consistently with connection fields. This allows extensions to inspect
+filters for permission/validation while keeping resolvers tolerant of missing
+params.


### PR DESCRIPTION
Ensure offset pagination passes pagination/order/filters through the extension chain and safely strips unsupported args from resolvers so extensions can inspect inputs consistently with connection fields.

Fix #853

## Summary by Sourcery

Ensure offset-paginated Django fields forward pagination, ordering, and filter arguments to extensions while stripping unsupported pagination arguments from resolvers, aligning behavior with connection fields.

Bug Fixes:
- Fix offset-paginated fields not passing pagination, ordering, and filter arguments through to field extensions.
- Avoid passing pagination arguments to offset-paginated resolvers that do not accept them, preventing unexpected resolver errors when using pagination inputs.

Tests:
- Add tests verifying offset-paginated extensions receive filter arguments.
- Add tests confirming offset-paginated fields work when the resolver does not declare a filters parameter.