### PR TITLE
docs: warn about ReDoS exposure on regex/iRegex filter lookups

### DIFF
--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -166,6 +166,19 @@ class FruitFilter:
 > instead to prevent `DuplicatedTypeName` errors. See the [Generic Lookup reference](#generic-lookup-reference)
 > for the full list of available lookup types.
 
+> [!WARNING]
+> `StrFilterLookup` and `FilterLookup` expose `regex` and `iRegex`, which forward the
+> pattern to Django's [`__regex` / `__iregex`](https://docs.djangoproject.com/en/stable/ref/models/querysets/#regex)
+> lookups. The regex engine is provided by the database backend, and SQLite (Python's `re`)
+> and MySQL (POSIX ERE) are vulnerable to catastrophic backtracking on crafted patterns
+> (ReDoS). PostgreSQL uses RE2 and is not affected.
+>
+> If untrusted users can submit filter input, prefer one of:
+>
+> - Use PostgreSQL, or
+> - Apply a database statement timeout, or
+> - Subclass the lookup type and omit `regex` / `iRegex` from the fields you expose.
+
 ## Filtering over relationships
 
 ```python title="types.py"
@@ -461,6 +474,7 @@ There is 7 already defined Generic Lookup `strawberry.input` classes importable 
 - inherits `BaseFilterLookup`
 - additionally contains `iExact`, `contains`, `iContains`, `startsWith`, `iStartsWith`, `endsWith`, `iEndsWith`, `regex` & `iRegex`
 - used for string based fields and as default
+- see the [warning on `regex` / `iRegex`](#lookups) before exposing these on untrusted input
 
 #### `DateFilterLookup`
 

--- a/docs/guide/filters.md
+++ b/docs/guide/filters.md
@@ -169,13 +169,11 @@ class FruitFilter:
 > [!WARNING]
 > `StrFilterLookup` and `FilterLookup` expose `regex` and `iRegex`, which forward the
 > pattern to Django's [`__regex` / `__iregex`](https://docs.djangoproject.com/en/stable/ref/models/querysets/#regex)
-> lookups. The regex engine is provided by the database backend, and SQLite (Python's `re`)
-> and MySQL (POSIX ERE) are vulnerable to catastrophic backtracking on crafted patterns
-> (ReDoS). PostgreSQL uses RE2 and is not affected.
+> lookups. Regex execution is provided by the database backend. Crafted patterns can cause
+> expensive backtracking or high CPU usage depending on backend behavior (ReDoS risk).
 >
 > If untrusted users can submit filter input, prefer one of:
 >
-> - Use PostgreSQL, or
 > - Apply a database statement timeout, or
 > - Subclass the lookup type and omit `regex` / `iRegex` from the fields you expose.
 


### PR DESCRIPTION
## Summary

- Adds a warning callout in `docs/guide/filters.md` explaining that `regex` / `iRegex` on `StrFilterLookup` and `FilterLookup` forward the pattern to Django's `__regex` / `__iregex`, and that SQLite and MySQL are vulnerable to ReDoS via catastrophic backtracking (PostgreSQL uses RE2 and is not affected).
- Lists the practical mitigations: use PostgreSQL, set a database statement timeout, or subclass the lookup type and drop the regex fields.
- Cross-links the new warning from the `FilterLookup` entry in the Generic Lookup reference.

Follow-up to GHSA-2pc2-g64x-539x, which is being closed as informative since the behavior is inherent to Django's regex lookups rather than specific to this library.

## Test plan

- [ ] Render the docs site locally and confirm the warning appears in the Lookups section and the cross-link in the Generic Lookup reference resolves.

## Summary by Sourcery

Document security implications and usage guidance for regex-based filter lookups in the filtering guide.

Documentation:
- Add a warning in the filters guide about ReDoS risks when using `regex` / `iRegex` filter lookups on certain database backends, with recommended mitigations and backend-specific notes.
- Cross-link the new regex warning from the Generic Lookup reference to guide safe exposure of these lookups on untrusted input.