### PR TITLE
fix: Date/Time/Datetime filter lookups without type parameter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,3 +9,9 @@ release type: minor
 class ProjectFilter:
     due_date: strawberry_django.DateFilterLookup | None
 ```
+
+Migrating:
+
+- Drop the type argument from `StrFilterLookup[str]`, `DateFilterLookup[datetime.date]`, etc. The bare lookup now works; using the bracket form raises `TypeError` at import time.
+- `DatetimeFilterLookup.date` and `.time` now accept `Date` / `Time` values (previously typed as `Int`, which never matched Django's `__date` / `__time` transforms).
+- `TimeFilterLookup.date` and `.time` were removed. Django's `__date` / `__time` transforms don't apply to `TimeField`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,6 @@ class ProjectFilter:
 
 Migrating:
 
-- Drop the type argument from `StrFilterLookup[str]`, `DateFilterLookup[datetime.date]`, etc. The bare lookup now works; using the bracket form raises `TypeError` at import time.
+- Drop the type argument from `StrFilterLookup[str]`, `DateFilterLookup[datetime.date]`, etc. The bare lookup now works; the bracket form still resolves to the same class but emits a `DeprecationWarning`.
 - `DatetimeFilterLookup.date` and `.time` now accept `Date` / `Time` values (previously typed as `Int`, which never matched Django's `__date` / `__time` transforms).
 - `TimeFilterLookup.date` and `.time` were removed. Django's `__date` / `__time` transforms don't apply to `TimeField`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+---
+release type: minor
+---
+
+`DateFilterLookup`, `TimeFilterLookup` and `DatetimeFilterLookup` no longer require a type parameter, matching `StrFilterLookup`. The generated GraphQL input names also lose their type prefix (e.g. `DateDateFilterLookup` becomes `DateFilterLookup`).
+
+```python
+@strawberry_django.filter_type(models.Project)
+class ProjectFilter:
+    due_date: strawberry_django.DateFilterLookup | None
+```

--- a/strawberry_django/fields/filter_types.py
+++ b/strawberry_django/fields/filter_types.py
@@ -21,6 +21,15 @@ T = TypeVar("T")
 _SKIP_MSG = "Filter will be skipped on `null` value"
 
 
+def _warn_concrete_lookup(cls: type) -> None:
+    warnings.warn(
+        f"{cls.__name__} is not generic; the type argument is ignored. "
+        "Use the bare class instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 @strawberry.input
 class BaseFilterLookup(Generic[T]):
     exact: T | None = filter_field(description=f"Exact match. {_SKIP_MSG}")
@@ -124,6 +133,10 @@ class StrFilterLookup(BaseFilterLookup[str]):
         description=f"Case-insensitive regular expression match. {_SKIP_MSG}"
     )
 
+    def __class_getitem__(cls, item: Any) -> type:
+        _warn_concrete_lookup(cls)
+        return cls
+
 
 @strawberry.input
 class DateFilterLookup(ComparisonFilterLookup[datetime.date]):
@@ -136,12 +149,20 @@ class DateFilterLookup(ComparisonFilterLookup[datetime.date]):
     iso_year: ComparisonFilterLookup[int] | None = UNSET
     quarter: ComparisonFilterLookup[int] | None = UNSET
 
+    def __class_getitem__(cls, item: Any) -> type:
+        _warn_concrete_lookup(cls)
+        return cls
+
 
 @strawberry.input
 class TimeFilterLookup(ComparisonFilterLookup[datetime.time]):
     hour: ComparisonFilterLookup[int] | None = UNSET
     minute: ComparisonFilterLookup[int] | None = UNSET
     second: ComparisonFilterLookup[int] | None = UNSET
+
+    def __class_getitem__(cls, item: Any) -> type:
+        _warn_concrete_lookup(cls)
+        return cls
 
 
 @strawberry.input
@@ -159,6 +180,10 @@ class DatetimeFilterLookup(ComparisonFilterLookup[datetime.datetime]):
     second: ComparisonFilterLookup[int] | None = UNSET
     date: ComparisonFilterLookup[datetime.date] | None = UNSET
     time: ComparisonFilterLookup[datetime.time] | None = UNSET
+
+    def __class_getitem__(cls, item: Any) -> type:
+        _warn_concrete_lookup(cls)
+        return cls
 
 
 type_filter_map = {

--- a/strawberry_django/fields/filter_types.py
+++ b/strawberry_django/fields/filter_types.py
@@ -142,8 +142,6 @@ class TimeFilterLookup(ComparisonFilterLookup[datetime.time]):
     hour: ComparisonFilterLookup[int] | None = UNSET
     minute: ComparisonFilterLookup[int] | None = UNSET
     second: ComparisonFilterLookup[int] | None = UNSET
-    date: ComparisonFilterLookup[int] | None = UNSET
-    time: ComparisonFilterLookup[int] | None = UNSET
 
 
 @strawberry.input
@@ -159,8 +157,8 @@ class DatetimeFilterLookup(ComparisonFilterLookup[datetime.datetime]):
     hour: ComparisonFilterLookup[int] | None = UNSET
     minute: ComparisonFilterLookup[int] | None = UNSET
     second: ComparisonFilterLookup[int] | None = UNSET
-    date: ComparisonFilterLookup[int] | None = UNSET
-    time: ComparisonFilterLookup[int] | None = UNSET
+    date: ComparisonFilterLookup[datetime.date] | None = UNSET
+    time: ComparisonFilterLookup[datetime.time] | None = UNSET
 
 
 type_filter_map = {

--- a/strawberry_django/fields/filter_types.py
+++ b/strawberry_django/fields/filter_types.py
@@ -124,12 +124,9 @@ class StrFilterLookup(BaseFilterLookup[str]):
         description=f"Case-insensitive regular expression match. {_SKIP_MSG}"
     )
 
-    def __class_getitem__(cls, item: Any) -> type:
-        return cls
-
 
 @strawberry.input
-class DateFilterLookup(ComparisonFilterLookup[T]):
+class DateFilterLookup(ComparisonFilterLookup[datetime.date]):
     year: ComparisonFilterLookup[int] | None = UNSET
     month: ComparisonFilterLookup[int] | None = UNSET
     day: ComparisonFilterLookup[int] | None = UNSET
@@ -141,7 +138,7 @@ class DateFilterLookup(ComparisonFilterLookup[T]):
 
 
 @strawberry.input
-class TimeFilterLookup(ComparisonFilterLookup[T]):
+class TimeFilterLookup(ComparisonFilterLookup[datetime.time]):
     hour: ComparisonFilterLookup[int] | None = UNSET
     minute: ComparisonFilterLookup[int] | None = UNSET
     second: ComparisonFilterLookup[int] | None = UNSET
@@ -150,8 +147,20 @@ class TimeFilterLookup(ComparisonFilterLookup[T]):
 
 
 @strawberry.input
-class DatetimeFilterLookup(DateFilterLookup[T], TimeFilterLookup[T]):
-    pass
+class DatetimeFilterLookup(ComparisonFilterLookup[datetime.datetime]):
+    year: ComparisonFilterLookup[int] | None = UNSET
+    month: ComparisonFilterLookup[int] | None = UNSET
+    day: ComparisonFilterLookup[int] | None = UNSET
+    week_day: ComparisonFilterLookup[int] | None = UNSET
+    iso_week_day: ComparisonFilterLookup[int] | None = UNSET
+    week: ComparisonFilterLookup[int] | None = UNSET
+    iso_year: ComparisonFilterLookup[int] | None = UNSET
+    quarter: ComparisonFilterLookup[int] | None = UNSET
+    hour: ComparisonFilterLookup[int] | None = UNSET
+    minute: ComparisonFilterLookup[int] | None = UNSET
+    second: ComparisonFilterLookup[int] | None = UNSET
+    date: ComparisonFilterLookup[int] | None = UNSET
+    time: ComparisonFilterLookup[int] | None = UNSET
 
 
 type_filter_map = {

--- a/strawberry_django/fields/types.py
+++ b/strawberry_django/fields/types.py
@@ -554,9 +554,16 @@ def resolve_model_field_type(
         if using_old_filters:
             field_type = filters.FilterLookup[field_type]
         else:
-            field_type = filter_types.type_filter_map.get(  # type: ignore
+            lookup_type: Any = filter_types.type_filter_map.get(
                 field_type, filter_types.FilterLookup
-            )[field_type]
+            )
+            # Concrete lookups (e.g. StrFilterLookup, DateFilterLookup) are not
+            # subscriptable; only parametrize when the lookup is still generic.
+            field_type = (
+                lookup_type[field_type]
+                if getattr(lookup_type, "__parameters__", ())
+                else lookup_type
+            )
 
     return field_type
 

--- a/tests/filters/test_filters_v2.py
+++ b/tests/filters/test_filters_v2.py
@@ -724,6 +724,57 @@ def test_str_filter_lookup_without_type_parameter():
     assert "input StrFilterLookup {" in schema.as_str()
 
 
+def test_date_filter_lookup_without_type_parameter():
+    @strawberry_django.filters.filter_type(models.Fruit)
+    class FruitFilter:
+        date: strawberry_django.DateFilterLookup | None
+
+    @strawberry_django.type(models.Fruit, filters=FruitFilter)
+    class FruitType:
+        name: auto
+
+    @strawberry.type
+    class Query:
+        fruits: list[FruitType] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query)
+    assert "input DateFilterLookup {" in schema.as_str()
+
+
+def test_time_filter_lookup_without_type_parameter():
+    @strawberry_django.filters.filter_type(models.Fruit)
+    class FruitFilter:
+        time: strawberry_django.TimeFilterLookup | None
+
+    @strawberry_django.type(models.Fruit, filters=FruitFilter)
+    class FruitType:
+        name: auto
+
+    @strawberry.type
+    class Query:
+        fruits: list[FruitType] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query)
+    assert "input TimeFilterLookup {" in schema.as_str()
+
+
+def test_datetime_filter_lookup_without_type_parameter():
+    @strawberry_django.filters.filter_type(models.Fruit)
+    class FruitFilter:
+        created_at: strawberry_django.DatetimeFilterLookup | None
+
+    @strawberry_django.type(models.Fruit, filters=FruitFilter)
+    class FruitType:
+        name: auto
+
+    @strawberry.type
+    class Query:
+        fruits: list[FruitType] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query)
+    assert "input DatetimeFilterLookup {" in schema.as_str()
+
+
 def test_process_filters_with_some_global_id_in_lookup():
     @strawberry_django.filters.filter_type(models.Fruit)
     class Filter:

--- a/tests/filters/test_process_filters_prefix.py
+++ b/tests/filters/test_process_filters_prefix.py
@@ -23,7 +23,7 @@ def test_process_filters_prefix(db):
             self,
             info: strawberry.Info,
             queryset: QuerySet,
-            value: filter_types.StrFilterLookup[str],
+            value: filter_types.StrFilterLookup,
             prefix: str,
         ) -> tuple[QuerySet, Q]:
             queryset = queryset.alias(
@@ -76,7 +76,7 @@ def test_process_filters_prefix_missing_trailing_underscores(db):
             self,
             info: strawberry.Info,
             queryset: QuerySet,
-            value: filter_types.StrFilterLookup[str],
+            value: filter_types.StrFilterLookup,
             prefix: str,
         ) -> tuple[QuerySet, Q]:
             queryset = queryset.alias(

--- a/tests/projects/snapshots/schema.gql
+++ b/tests/projects/snapshots/schema.gql
@@ -107,7 +107,7 @@ union CreateQuizPayload = QuizType | OperationInfo
 """Date (isoformat)"""
 scalar Date
 
-input DateDateFilterLookup {
+input DateFilterLookup {
   """Exact match. Filter will be skipped on `null` value"""
   exact: Date
 
@@ -559,7 +559,7 @@ type ProjectConnection {
 
 input ProjectFilter {
   name: StrFilterLookup
-  dueDate: DateDateFilterLookup
+  dueDate: DateFilterLookup
   AND: ProjectFilter
   OR: ProjectFilter
   NOT: ProjectFilter


### PR DESCRIPTION
Closes #907.

`DateFilterLookup`, `TimeFilterLookup` and `DatetimeFilterLookup` were declared `Generic[T]` but always used with a fixed type, so referencing them without `[T]` raised `TypeError: ... is generic, but no type has been passed`. Made them concrete (mirroring the `StrFilterLookup` fix from #891) and refactored the auto-resolution path at `fields/types.py` so concrete lookups aren't subscripted. Also dropped the now-unneeded `__class_getitem__` hack from `StrFilterLookup`.

## Breaking change

Generated GraphQL input names lose their type prefix: `DateDateFilterLookup` becomes `DateFilterLookup`. Clients referencing these inputs by name need to update. Bumping as `minor` for this reason.

## Test plan

- [x] Added repro tests for Date/Time/Datetime lookups without type param
- [x] All 1171 tests pass, pyright and ruff clean
- [x] Schema snapshot updated to reflect the rename

## Summary by Sourcery

Make date, time, and datetime filter lookups concrete types and adjust filter type resolution to avoid subscripting non-generic lookups.

Bug Fixes:
- Allow DateFilterLookup, TimeFilterLookup, and DatetimeFilterLookup to be referenced without a type parameter in filters and schema generation.

Enhancements:
- Update DatetimeFilterLookup to define its own date/time component fields instead of inheriting from generic date/time lookups.
- Adjust filter type auto-resolution to only parametrize genuinely generic lookup types, aligning behavior across string and temporal lookups.

Documentation:
- Add RELEASE.md entry documenting the change in filter lookup typing and the resulting GraphQL input name changes.

Tests:
- Add regression tests ensuring Date/Time/Datetime filter lookups work without explicit type parameters and update schema snapshot expectations accordingly.