### PR TITLE
Fix offset paginated double filter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+---
+release type: patch
+---
+
+Fix `offset_paginated` fields applying the filter pipeline twice per resolution.
+
+`StrawberryOffsetPaginatedExtension.resolve` forwards `filters`/`order`/`pagination`
+to the inner resolver (so extensions and custom resolvers can access them), but then
+re-applied them on the queryset the resolver returned. Filters, permission filtering
+and the optimizer pass all ran twice; for a filter spanning a multivalued relation
+the second `.filter()` duplicated the relation JOINs, which can grow the intermediate
+row count quadratically and turn a sub-second query into a multi-minute one.
+
+The queryset returned by the inner resolver is now passed straight to
+`resolve_paginated`, matching the behavior of relay connection fields.

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -557,6 +557,15 @@ class StrawberryOffsetPaginatedExtension(FieldExtension):
             forwarded_kwargs["order"] = order
         if "filters" not in forwarded_kwargs:
             forwarded_kwargs["filters"] = filters
+        # `filters`/`order`/`pagination` are forwarded to the inner resolver (above)
+        # so field extensions and custom resolvers can access them (see #853/#854).
+        # The inner resolver already applies them via ``get_queryset_hook`` ->
+        # ``get_queryset``, so we must NOT apply them again here. Re-applying runs
+        # the filter pipeline twice, and a second ``queryset.filter(...)`` makes
+        # Django emit a duplicate set of JOINs for any multivalued relation in the
+        # filter, squaring the row count of the resulting query.
+        # This mirrors ``StrawberryDjangoConnectionExtension.resolve`` above, which
+        # likewise passes the ``next_`` result straight to ``resolve_connection``.
         queryset = cast(
             "models.QuerySet",
             next_(
@@ -566,22 +575,13 @@ class StrawberryOffsetPaginatedExtension(FieldExtension):
             ),
         )
 
-        def get_queryset(queryset):
-            return cast("StrawberryDjangoField", info._field).get_queryset(
-                queryset,
-                info,
-                pagination=pagination,
-                order=order,
-                filters=filters,
-            )
-
         # We have a single resolver for both sync and async, so we need to check if
         # nodes is awaitable or not and resolve it accordingly
         if inspect.isawaitable(queryset):
 
             async def async_resolver(queryset=queryset):
                 resolved = self.paginated_type.resolve_paginated(
-                    get_queryset(await queryset),
+                    await queryset,
                     info=info,
                     pagination=pagination,
                     **kwargs,
@@ -594,7 +594,7 @@ class StrawberryOffsetPaginatedExtension(FieldExtension):
             return async_resolver()
 
         return self.paginated_type.resolve_paginated(
-            get_queryset(queryset),
+            queryset,
             info=info,
             pagination=pagination,
             **kwargs,

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -1190,3 +1190,140 @@ def test_offset_paginated_allows_filters_without_resolver_param():
 
     assert res.errors is None
     assert res.data == {"fruits": {"results": [{"name": "Apple"}]}}
+
+
+@pytest.mark.django_db(transaction=True)
+def test_offset_paginated_applies_filter_pipeline_only_once():
+    """The filter pipeline must run exactly once per OffsetPaginated resolution.
+
+    The OffsetPaginated extension forwards ``filters``/``order``/``pagination`` to
+    the inner resolver so extensions and custom resolvers can read them (see
+    ``test_offset_paginated_extensions_receive_filters``, added for #853/#854).
+    The inner resolver already applies them via ``get_queryset``; the extension
+    must therefore NOT re-apply them in its own ``get_queryset`` closure.
+
+    Re-applying runs the whole filter pipeline twice. For a filter that spans a
+    multivalued relation, the second ``queryset.filter(...)`` makes Django emit a
+    *second*, independent set of JOINs, squaring the row count of the query (this
+    is what took a production query from <1s to >30s).
+    """
+    from django.db.models import Q
+
+    call_count = 0
+
+    @strawberry_django.filter_type(models.Fruit)
+    class FruitFilter:
+        @strawberry_django.filter_field
+        def name_contains(self, queryset, value: str, prefix: str):
+            nonlocal call_count
+            call_count += 1
+            return queryset, Q(**{f"{prefix}name__icontains": value})
+
+    @strawberry_django.type(models.Fruit, filters=FruitFilter)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry.type
+    class Query:
+        fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated(
+            filters=FruitFilter
+        )
+
+    schema = strawberry.Schema(query=Query)
+    models.Fruit.objects.create(name="Apple")
+
+    query = """
+      query ($filters: FruitFilter) {
+        fruits(filters: $filters) {
+          results { name }
+        }
+      }
+    """
+    res = schema.execute_sync(
+        query, variable_values={"filters": {"nameContains": "App"}}
+    )
+
+    assert res.errors is None
+    assert res.data == {"fruits": {"results": [{"name": "Apple"}]}}
+    assert call_count == 1, (
+        f"filter pipeline ran {call_count} times for a single OffsetPaginated "
+        "resolution (expected 1); it is being applied twice"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_offset_paginated_does_not_duplicate_relation_joins():
+    """Filtering an OffsetPaginated field on a relation must not double the JOINs.
+
+    Regression test for the double-filter bug: an OffsetPaginated field must emit
+    the same relation JOINs as the equivalent non-paginated list field. The bug
+    applied the filter twice, so the paginated query joined the related table
+    twice (e.g. ``tests_group_tags`` appearing as two aliases), squaring rows.
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    @strawberry_django.filter_type(models.Tag, lookups=True)
+    class TagFilter:
+        name: strawberry.auto
+
+    @strawberry_django.filter_type(models.Group, lookups=True)
+    class GroupFilter:
+        name: strawberry.auto
+        tags: TagFilter | None
+
+    @strawberry_django.type(models.Group, filters=GroupFilter)
+    class GroupType:
+        id: int
+        name: str
+
+    @strawberry.type
+    class Query:
+        groups_paginated: OffsetPaginated[GroupType] = (
+            strawberry_django.offset_paginated(filters=GroupFilter)
+        )
+        groups_list: list[GroupType] = strawberry_django.field(filters=GroupFilter)
+
+    schema = strawberry.Schema(query=Query)
+    group = models.Group.objects.create(name="g1")
+    tag = models.Tag.objects.create(name="t1")
+    group.tags.add(tag)
+
+    variables = {"filters": {"tags": {"name": {"exact": "t1"}}}}
+
+    list_query = """
+      query ($filters: GroupFilter) {
+        groupsList(filters: $filters) { name }
+      }
+    """
+    with CaptureQueriesContext(connection) as list_ctx:
+        list_res = schema.execute_sync(list_query, variable_values=variables)
+    assert list_res.errors is None
+    list_sql = next(
+        q["sql"]
+        for q in list_ctx.captured_queries
+        if q["sql"].lstrip().upper().startswith("SELECT") and "tests_group" in q["sql"]
+    )
+    list_joins = list_sql.upper().count(" JOIN ")
+
+    paginated_query = """
+      query ($filters: GroupFilter) {
+        groupsPaginated(filters: $filters) { results { name } }
+      }
+    """
+    with CaptureQueriesContext(connection) as pag_ctx:
+        pag_res = schema.execute_sync(paginated_query, variable_values=variables)
+    assert pag_res.errors is None
+    pag_sql = next(
+        q["sql"]
+        for q in pag_ctx.captured_queries
+        if q["sql"].lstrip().upper().startswith("SELECT") and "tests_group" in q["sql"]
+    )
+    pag_joins = pag_sql.upper().count(" JOIN ")
+
+    assert pag_joins == list_joins, (
+        f"OffsetPaginated query has {pag_joins} JOINs but the equivalent list "
+        f"query has {list_joins}; the relation filter is being applied twice.\n"
+        f"paginated SQL: {pag_sql}"
+    )

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -1327,3 +1327,57 @@ def test_offset_paginated_does_not_duplicate_relation_joins():
         f"query has {list_joins}; the relation filter is being applied twice.\n"
         f"paginated SQL: {pag_sql}"
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_offset_paginated_runs_perms_optimizer_and_type_hook_once(mocker):
+    """An OffsetPaginated resolution must run the get_queryset pipeline once.
+
+    The extension forwards filters/order/pagination to the inner resolver (#854),
+    which already runs ``get_queryset_hook`` -> ``get_queryset``. The extension
+    must not call ``get_queryset`` a second time, otherwise permission filtering
+    (``filter_with_perms``) and the optimizer pass silently run twice (and
+    relation filters duplicate their JOINs). The type-level ``get_queryset`` hook
+    is guarded by ``type_get_queryset_did_run`` and runs once regardless.
+    """
+    from strawberry_django.fields import field as field_mod
+    from strawberry_django.optimizer import DjangoOptimizerExtension
+
+    type_get_queryset_calls = 0
+
+    @strawberry_django.filter_type(models.Fruit, lookups=True)
+    class FruitFilter:
+        name: strawberry.auto
+
+    @strawberry_django.type(models.Fruit, filters=FruitFilter)
+    class Fruit:
+        id: int
+        name: str
+
+        @classmethod
+        def get_queryset(cls, queryset, info, **kwargs):
+            nonlocal type_get_queryset_calls
+            type_get_queryset_calls += 1
+            return queryset
+
+    @strawberry.type
+    class Query:
+        fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated(
+            filters=FruitFilter
+        )
+
+    perms_spy = mocker.spy(field_mod, "filter_with_perms")
+    optimize_spy = mocker.spy(DjangoOptimizerExtension, "optimize")
+
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension()])
+    models.Fruit.objects.create(name="Apple")
+
+    res = schema.execute_sync(
+        "query ($f: FruitFilter){ fruits(filters: $f){ results { name } } }",
+        variable_values={"f": {"name": {"exact": "Apple"}}},
+    )
+
+    assert res.errors is None
+    assert perms_spy.call_count == 1  # was 2 before the fix
+    assert optimize_spy.call_count == 1  # was 2 before the fix
+    assert type_get_queryset_calls == 1  # guarded by type_get_queryset_did_run

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -1381,3 +1381,145 @@ def test_offset_paginated_runs_perms_optimizer_and_type_hook_once(mocker):
     assert perms_spy.call_count == 1  # was 2 before the fix
     assert optimize_spy.call_count == 1  # was 2 before the fix
     assert type_get_queryset_calls == 1  # guarded by type_get_queryset_did_run
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_offset_paginated_applies_filter_pipeline_only_once_async():
+    """Async variant of ``test_offset_paginated_applies_filter_pipeline_only_once``.
+
+    Exercises the awaitable branch of ``StrawberryOffsetPaginatedExtension.resolve``;
+    the filter pipeline must still run exactly once.
+    """
+    from django.db.models import Q
+
+    call_count = 0
+
+    @strawberry_django.filter_type(models.Fruit)
+    class FruitFilter:
+        @strawberry_django.filter_field
+        def name_contains(self, queryset, value: str, prefix: str):
+            nonlocal call_count
+            call_count += 1
+            return queryset, Q(**{f"{prefix}name__icontains": value})
+
+    @strawberry_django.type(models.Fruit, filters=FruitFilter)
+    class Fruit:
+        id: int
+        name: str
+
+    @strawberry.type
+    class Query:
+        fruits: OffsetPaginated[Fruit] = strawberry_django.offset_paginated(
+            filters=FruitFilter
+        )
+
+    schema = strawberry.Schema(query=Query)
+    await models.Fruit.objects.acreate(name="Apple")
+
+    query = """
+      query ($filters: FruitFilter) {
+        fruits(filters: $filters) {
+          results { name }
+        }
+      }
+    """
+    res = await schema.execute(
+        query, variable_values={"filters": {"nameContains": "App"}}
+    )
+
+    assert res.errors is None
+    assert res.data == {"fruits": {"results": [{"name": "Apple"}]}}
+    assert call_count == 1, (
+        f"filter pipeline ran {call_count} times for a single async OffsetPaginated "
+        "resolution (expected 1); it is being applied twice"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_offset_paginated_does_not_duplicate_joins_with_or_across_relations():
+    """OR across two multivalued relations + DISTINCT must not double the JOINs.
+
+    Mirrors the query shape that originally surfaced the double-filter bug: an
+    ``OR`` spanning two multivalued relations with ``DISTINCT``. The paginated
+    field must emit the same JOINs as the equivalent non-paginated list field;
+    the bug applied the filter twice, joining each relation twice and squaring
+    the row count.
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    @strawberry_django.filter_type(models.Tag, lookups=True)
+    class TagFilter:
+        name: strawberry.auto
+
+    @strawberry_django.filter_type(models.User, lookups=True)
+    class UserFilter:
+        name: strawberry.auto
+
+    @strawberry_django.filter_type(models.Group, lookups=True)
+    class GroupFilter:
+        name: strawberry.auto
+        tags: TagFilter | None
+        users: UserFilter | None
+
+    @strawberry_django.type(models.Group, filters=GroupFilter)
+    class GroupType:
+        id: int
+        name: str
+
+    @strawberry.type
+    class Query:
+        groups_paginated: OffsetPaginated[GroupType] = (
+            strawberry_django.offset_paginated(filters=GroupFilter)
+        )
+        groups_list: list[GroupType] = strawberry_django.field(filters=GroupFilter)
+
+    schema = strawberry.Schema(query=Query)
+    group = models.Group.objects.create(name="g1")
+    tag = models.Tag.objects.create(name="t1")
+    group.tags.add(tag)
+    models.User.objects.create(name="u1", group=group)
+
+    variables = {
+        "filters": {
+            "tags": {"name": {"exact": "t1"}},
+            "OR": {"users": {"name": {"exact": "u1"}}},
+            "DISTINCT": True,
+        }
+    }
+
+    list_query = """
+      query ($filters: GroupFilter) {
+        groupsList(filters: $filters) { name }
+      }
+    """
+    with CaptureQueriesContext(connection) as list_ctx:
+        list_res = schema.execute_sync(list_query, variable_values=variables)
+    assert list_res.errors is None
+    list_sql = next(
+        q["sql"]
+        for q in list_ctx.captured_queries
+        if q["sql"].lstrip().upper().startswith("SELECT") and "tests_group" in q["sql"]
+    )
+    list_joins = list_sql.upper().count(" JOIN ")
+
+    paginated_query = """
+      query ($filters: GroupFilter) {
+        groupsPaginated(filters: $filters) { results { name } }
+      }
+    """
+    with CaptureQueriesContext(connection) as pag_ctx:
+        pag_res = schema.execute_sync(paginated_query, variable_values=variables)
+    assert pag_res.errors is None
+    pag_sql = next(
+        q["sql"]
+        for q in pag_ctx.captured_queries
+        if q["sql"].lstrip().upper().startswith("SELECT") and "tests_group" in q["sql"]
+    )
+    pag_joins = pag_sql.upper().count(" JOIN ")
+
+    assert pag_joins == list_joins, (
+        f"OffsetPaginated query has {pag_joins} JOINs but the equivalent list "
+        f"query has {list_joins}; the OR/relation filter is being applied twice.\n"
+        f"paginated SQL: {pag_sql}"
+    )

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -3,11 +3,13 @@ from typing import Annotated
 
 import pytest
 import strawberry
-from django.db.models import QuerySet
-from django.test.utils import override_settings
+from django.db import connection
+from django.db.models import Q, QuerySet
+from django.test.utils import CaptureQueriesContext, override_settings
 from strawberry.extensions.field_extension import FieldExtension
 
 import strawberry_django
+from strawberry_django.fields import field as field_mod
 from strawberry_django.optimizer import DjangoOptimizerExtension
 from strawberry_django.pagination import OffsetPaginated, OffsetPaginationInput
 from strawberry_django.settings import StrawberryDjangoSettings
@@ -1207,8 +1209,6 @@ def test_offset_paginated_applies_filter_pipeline_only_once():
     *second*, independent set of JOINs, squaring the row count of the query (this
     is what took a production query from <1s to >30s).
     """
-    from django.db.models import Q
-
     call_count = 0
 
     @strawberry_django.filter_type(models.Fruit)
@@ -1261,8 +1261,6 @@ def test_offset_paginated_does_not_duplicate_relation_joins():
     applied the filter twice, so the paginated query joined the related table
     twice (e.g. ``tests_group_tags`` appearing as two aliases), squaring rows.
     """
-    from django.db import connection
-    from django.test.utils import CaptureQueriesContext
 
     @strawberry_django.filter_type(models.Tag, lookups=True)
     class TagFilter:
@@ -1340,9 +1338,6 @@ def test_offset_paginated_runs_perms_optimizer_and_type_hook_once(mocker):
     relation filters duplicate their JOINs). The type-level ``get_queryset`` hook
     is guarded by ``type_get_queryset_did_run`` and runs once regardless.
     """
-    from strawberry_django.fields import field as field_mod
-    from strawberry_django.optimizer import DjangoOptimizerExtension
-
     type_get_queryset_calls = 0
 
     @strawberry_django.filter_type(models.Fruit, lookups=True)
@@ -1390,8 +1385,6 @@ async def test_offset_paginated_applies_filter_pipeline_only_once_async():
     Exercises the awaitable branch of ``StrawberryOffsetPaginatedExtension.resolve``;
     the filter pipeline must still run exactly once.
     """
-    from django.db.models import Q
-
     call_count = 0
 
     @strawberry_django.filter_type(models.Fruit)
@@ -1445,8 +1438,6 @@ def test_offset_paginated_does_not_duplicate_joins_with_or_across_relations():
     the bug applied the filter twice, joining each relation twice and squaring
     the row count.
     """
-    from django.db import connection
-    from django.test.utils import CaptureQueriesContext
 
     @strawberry_django.filter_type(models.Tag, lookups=True)
     class TagFilter:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Fixes offset pagination doublicating joins (quadratically increasing runtime).

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #912 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. -> as far as I can tell, yes.
- [ ] My change requires a change to the documentation. -> no
- [ ] I have updated the documentation accordingly. -> no need I think
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage). -> ran the test suite

## Summary by Sourcery

Prevent offset-paginated fields from reapplying filters and query hooks, avoiding duplicated relation joins and quadratic query growth.

Bug Fixes:
- Fix offset pagination so the filter pipeline and queryset hooks run only once per resolution, preventing duplicated JOINs and excessive query times.

Tests:
- Add regression tests to ensure offset-paginated fields do not re-run the filter pipeline, do not duplicate relation JOINs (including OR across relations with DISTINCT), and only invoke permission/optimizer hooks once in both sync and async execution paths.