### PR TITLE
fix: accept QuerySet return annotation on connection resolvers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,17 @@
+---
+release type: patch
+---
+
+Connection resolvers can now be annotated with a `QuerySet[Model]` return type
+instead of being forced to widen it to `Iterable[Model]`:
+
+```python
+@strawberry_django.connection(DjangoCursorConnection[FruitType])
+@staticmethod
+def fruits() -> QuerySet[Fruit]:
+    return Fruit.objects.all()
+```
+
+Previously this raised `RelayWrongResolverAnnotationError` because Django's
+`QuerySet[Model]` collapses to the bare `QuerySet` class, which the relay
+annotation check did not recognize as iterable.

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -69,6 +69,7 @@ from strawberry_django.resolvers import (
     django_resolver,
     resolve_base_manager,
 )
+from strawberry_django.utils.inspect import callable_returns_queryset
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -475,7 +476,25 @@ class StrawberryDjangoConnectionExtension(relay.ConnectionExtension):
 
             field.base_resolver = StrawberryResolver(default_resolver)
 
-        return super().apply(field)
+        # Django's ``QuerySet.__class_getitem__`` returns the bare class, so a
+        # ``QuerySet[Foo]`` return annotation collapses to ``QuerySet`` and
+        # upstream's ``get_origin()``-based iterable check rejects it even though
+        # ``QuerySet`` is a genuine ``Iterable``. Normalize it to a plain list for
+        # the duration of ``super().apply()``; the annotation is only used there.
+        resolver = field.base_resolver
+        original_signature = resolver.__dict__.get("signature", UNSET)
+        if callable_returns_queryset(resolver):
+            resolver.__dict__["signature"] = resolver.signature.replace(
+                return_annotation=list[Any]
+            )
+
+        try:
+            return super().apply(field)
+        finally:
+            if original_signature is UNSET:
+                resolver.__dict__.pop("signature", None)
+            else:
+                resolver.__dict__["signature"] = original_signature
 
     def resolve(
         self,

--- a/strawberry_django/utils/inspect.py
+++ b/strawberry_django/utils/inspect.py
@@ -400,7 +400,10 @@ def callable_returns_queryset(resolver: StrawberryResolver) -> bool:
         annotation = eval_type(annotation, resolver._namespace, None)
 
     if is_union(annotation) and is_optional(annotation):
-        annotation = get_args(annotation)[0]
+        non_none = [a for a in get_args(annotation) if a is not type(None)]
+        if len(non_none) != 1:
+            return False
+        annotation = non_none[0]
 
     origin = get_origin(annotation) or annotation
     return isinstance(origin, type) and issubclass(origin, QuerySet)

--- a/strawberry_django/utils/inspect.py
+++ b/strawberry_django/utils/inspect.py
@@ -7,7 +7,10 @@ import weakref
 from typing import (
     TYPE_CHECKING,
     Any,
+    ForwardRef,
     cast,
+    get_args,
+    get_origin,
 )
 
 from django.db.models.query import Prefetch, QuerySet
@@ -23,6 +26,7 @@ from strawberry.types.base import (
 from strawberry.types.lazy_type import LazyType
 from strawberry.types.union import StrawberryUnion
 from strawberry.utils.str_converters import to_camel_case
+from strawberry.utils.typing import eval_type, is_optional, is_union
 from typing_extensions import TypeIs, assert_never
 
 from strawberry_django.fields.types import resolve_model_field_name
@@ -43,6 +47,7 @@ if TYPE_CHECKING:
         InheritanceQuerySetMixin,
     )
     from polymorphic.models import PolymorphicModel
+    from strawberry.types.fields.resolver import StrawberryResolver
 
 
 @functools.lru_cache
@@ -384,3 +389,18 @@ class PrefetchInspector:
         self.prefetch_related = prefetch_related.values()
 
         return self
+
+
+def callable_returns_queryset(resolver: StrawberryResolver) -> bool:
+    """Check whether a resolver's return annotation resolves to a `QuerySet`."""
+    annotation = resolver.signature.return_annotation
+    if isinstance(annotation, str):
+        annotation = ForwardRef(annotation)
+    if isinstance(annotation, ForwardRef):
+        annotation = eval_type(annotation, resolver._namespace, None)
+
+    if is_union(annotation) and is_optional(annotation):
+        annotation = get_args(annotation)[0]
+
+    origin = get_origin(annotation) or annotation
+    return isinstance(origin, type) and issubclass(origin, QuerySet)

--- a/tests/test_custom_connection.py
+++ b/tests/test_custom_connection.py
@@ -96,14 +96,17 @@ def test_connection_resolver_with_queryset_annotation():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_connection_resolver_with_queryset_annotation_resolves():
+@pytest.mark.parametrize(
+    "connection_type", [DjangoListConnection, DjangoCursorConnection]
+)
+def test_connection_resolver_with_queryset_annotation_resolves(connection_type):
     """A `QuerySet[Model]`-annotated resolver resolves its nodes correctly."""
     User.objects.create(name="user1")
     User.objects.create(name="user2")
 
     @strawberry.type
     class QuerySetQuery:
-        @strawberry_django.connection(DjangoListConnection[UserType])
+        @strawberry_django.connection(connection_type[UserType])
         def users(self) -> QuerySet[User]:
             return User.objects.all().order_by("name")
 

--- a/tests/test_custom_connection.py
+++ b/tests/test_custom_connection.py
@@ -4,12 +4,13 @@ from typing import Any
 import pytest
 import strawberry
 from django.db import connections
+from django.db.models import QuerySet
 from django.test.utils import CaptureQueriesContext
 from strawberry import Info, auto, relay
 
 import strawberry_django
 from strawberry_django.optimizer import DjangoOptimizerExtension
-from strawberry_django.relay import DjangoListConnection
+from strawberry_django.relay import DjangoCursorConnection, DjangoListConnection
 from tests.models import Group, Tag, User
 
 
@@ -63,6 +64,57 @@ class Query:
     )
     def users(self, info: Info) -> Iterable[User]:
         return User.objects.all()
+
+
+def test_connection_resolver_with_queryset_annotation():
+    """A `QuerySet[Model]` return annotation must not break schema building.
+
+    Django's ``QuerySet.__class_getitem__`` returns the bare class, so
+    ``QuerySet[User]`` collapses to ``QuerySet`` and the upstream relay check
+    used to reject it even though ``QuerySet`` is iterable (#917).
+    """
+
+    @strawberry.type
+    class QuerySetQuery:
+        @strawberry_django.connection(DjangoListConnection[UserType])
+        def users_list(self) -> QuerySet[User]:
+            return User.objects.all()
+
+        @strawberry_django.connection(DjangoCursorConnection[UserType])
+        def users_cursor(self) -> QuerySet[User]:
+            return User.objects.all()
+
+        @strawberry_django.connection(DjangoListConnection[UserType])
+        def users_optional(self) -> QuerySet[User] | None:
+            return User.objects.all()
+
+        @strawberry_django.connection(DjangoListConnection[UserType])
+        async def users_async(self) -> QuerySet[User]:
+            return User.objects.all()
+
+    strawberry.Schema(query=QuerySetQuery)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_connection_resolver_with_queryset_annotation_resolves():
+    """A `QuerySet[Model]`-annotated resolver resolves its nodes correctly."""
+    User.objects.create(name="user1")
+    User.objects.create(name="user2")
+
+    @strawberry.type
+    class QuerySetQuery:
+        @strawberry_django.connection(DjangoListConnection[UserType])
+        def users(self) -> QuerySet[User]:
+            return User.objects.all().order_by("name")
+
+    schema = strawberry.Schema(query=QuerySetQuery)
+
+    result = schema.execute_sync("{ users { edges { node { name } } } }")
+
+    assert result.errors is None
+    assert result.data == {
+        "users": {"edges": [{"node": {"name": "user1"}}, {"node": {"name": "user2"}}]}
+    }
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Fixes #917

Connection resolvers can now be annotated with `QuerySet[Model]` instead of being forced to widen the return type to `Iterable[Model]`.

## Problem

Django's `QuerySet.__class_getitem__` returns the bare class, so `QuerySet[Fruit]` evaluates to plain `QuerySet`. The relay annotation check in strawberry (`ConnectionExtension.apply`) calls `get_origin()` on the resolver's return type, which is `None` for a bare class, so it raised `RelayWrongResolverAnnotationError` even though `QuerySet` is iterable.

```python
@strawberry_django.connection(DjangoCursorConnection[FruitType])
@staticmethod
def fruits() -> QuerySet[Fruit]:
    return Fruit.objects.all()
```

## Fix

In `StrawberryDjangoConnectionExtension.apply`, detect when the resolver's return annotation resolves to a `QuerySet` (new `callable_returns_queryset` helper in `utils/inspect.py`, handling `str`/`ForwardRef`, `Optional`, and the bare-class collapse) and temporarily normalize the resolver's cached signature to `list[Any]` for the duration of the upstream check. That annotation is only consumed by the iterable validation; the GraphQL type comes from the connection generic. The original signature is restored in a `finally`.

Covers `DjangoCursorConnection`, `DjangoListConnection`, and `QuerySet` subclasses, sync and async.

## Summary by Sourcery

Allow Django connection resolvers to use QuerySet return annotations without breaking relay iterable checks.

Bug Fixes:
- Treat resolvers annotated with QuerySet[Model] (including optional and async cases) as valid iterables during connection field setup to avoid RelayWrongResolverAnnotationError.

Enhancements:
- Introduce a helper to detect when a resolver’s return annotation resolves to a QuerySet and temporarily normalize it to a list for relay validation.
- Document the behavior change and example usage in the release notes.

Documentation:
- Add release notes explaining support for QuerySet[Model] return annotations on connection resolvers.

Tests:
- Add integration tests ensuring QuerySet-annotated connection resolvers build the schema and resolve nodes correctly.