### PR TITLE
fix: avoid sync_to_async thread hop when resolving node id

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+---
+release type: patch
+---
+
+Resolving a Relay node's `id` no longer goes through `sync_to_async` on every call.
+`resolve_id`/`resolve_id_attr` now read the primary key directly off the in-memory
+instance, removing an unnecessary thread hop (and contextvars copy) in async contexts.
+The deferred-field fallback still bridges database access safely.

--- a/strawberry_django/relay/utils.py
+++ b/strawberry_django/relay/utils.py
@@ -283,7 +283,9 @@ def resolve_model_node(
 
 
 def resolve_model_id_attr(source: type) -> str:
-    """Resolve the model id, ensuring it is retrieved in a sync context.
+    """Resolve the name of the model attribute holding the node id.
+
+    This is a pure annotation scan, so it never touches the database.
 
     Args:
     ----
@@ -309,7 +311,11 @@ def resolve_model_id(
     *,
     info: Info | None = None,
 ) -> AwaitableOrValue[str]:
-    """Resolve the model id, ensuring it is retrieved in a sync context.
+    """Resolve the model id, reading it off the in-memory instance.
+
+    The pk is read directly from the instance's ``__dict__``, so the common case
+    stays synchronous. Only a deferred id field falls back to ``django_getattr``,
+    which bridges the resulting database read to the current sync/async context.
 
     Args:
     ----

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -213,17 +213,21 @@ def _process_type(
     # Default querying methods for relay
     if issubclass(cls, relay.Node):
         for attr, func in [
+            # resolve_id / resolve_id_attr read the pk off the in-memory instance;
+            # wrapping them in django_resolver would force every id resolution
+            # through sync_to_async (a thread hop) in async contexts. They bridge
+            # the rare deferred-field DB read themselves via django_getattr.
             ("resolve_id", resolve_model_id),
             ("resolve_id_attr", resolve_model_id_attr),
-            ("resolve_node", resolve_model_node),
-            ("resolve_nodes", resolve_model_nodes),
+            ("resolve_node", django_resolver(resolve_model_node)),
+            ("resolve_nodes", django_resolver(resolve_model_nodes)),
         ]:
             existing_resolver = getattr(cls, attr, None)
             if (
                 existing_resolver is None
                 or existing_resolver.__func__ is getattr(relay.Node, attr).__func__
             ):
-                setattr(cls, attr, types.MethodType(django_resolver(func), cls))  # type: ignore
+                setattr(cls, attr, types.MethodType(func, cls))
 
             # Adjust types that inherit from other types/interfaces that implement Node
             # to make sure they pass themselves as the node type

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,3 +1,7 @@
+import asyncio
+import inspect
+from typing import Any, cast
+
 import strawberry
 from strawberry import auto, relay
 from typing_extensions import Self
@@ -82,3 +86,22 @@ def test_relay_with_resolve_id_and_node_id():
     assert str(schema) == expected_schema.strip()
     # check that resolve_id_attr resolves correctly
     assert UserType.resolve_id_attr() == "id"
+
+
+async def test_resolve_id_is_sync_in_async_context():
+    @strawberry_django.type(User)
+    class DefaultPkType(relay.Node):
+        name: auto
+
+    @strawberry_django.type(User)
+    class NodeIdType(relay.Node):
+        id: relay.NodeID[int]
+        name: auto
+
+    # Resolving the id off an in-memory instance must not hop threads via
+    # sync_to_async, even when called inside an async context.
+    await asyncio.sleep(0)  # ensure a running event loop (in_async_context() is true)
+    for node_type in (DefaultPkType, NodeIdType):
+        result = node_type.resolve_id(cast("Any", User(pk=1)), info=cast("Any", None))
+        assert result == "1"
+        assert not inspect.isawaitable(result)

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2,7 +2,9 @@ import asyncio
 import inspect
 from typing import Any, cast
 
+import pytest
 import strawberry
+from asgiref.sync import sync_to_async
 from strawberry import auto, relay
 from typing_extensions import Self
 
@@ -105,3 +107,20 @@ async def test_resolve_id_is_sync_in_async_context():
         result = node_type.resolve_id(cast("Any", User(pk=1)), info=cast("Any", None))
         assert result == "1"
         assert not inspect.isawaitable(result)
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_resolve_id_deferred_field_bridges_to_sync():
+    @strawberry_django.type(User)
+    class NameNodeType(relay.Node):
+        name: relay.NodeID[str]
+
+    user = await sync_to_async(User.objects.create)(name="foobar")
+    instance = await sync_to_async(User.objects.only("id").get)(pk=user.pk)
+
+    # The node id field is deferred, so it is absent from __dict__ and
+    # resolve_model_id must fall back to django_getattr, which bridges the
+    # database read off the event loop instead of running it inline.
+    result = NameNodeType.resolve_id(cast("Any", instance), info=cast("Any", None))
+    assert inspect.isawaitable(result)
+    assert await result == "foobar"


### PR DESCRIPTION
Fixes #913.

## Problem

Profiling in #913 traced slow `id` resolution to `Node.resolve_id` going through `sync_to_async` on every call.

When `@strawberry_django.type` processes a `relay.Node` subclass, it wraps all four default relay resolvers (`resolve_id`, `resolve_id_attr`, `resolve_node`, `resolve_nodes`) in `django_resolver` and binds them to the class. In an async context, `django_resolver` routes through `@sync_to_async` (`thread_sensitive=True`), which costs a thread hop into asgiref's shared executor plus a contextvars copy on every call.

That cost is warranted for `resolve_node`/`resolve_nodes`, which query the database, but not for `resolve_id`/`resolve_id_attr`:

- `resolve_model_id_attr` is a pure annotation scan with no I/O.
- `resolve_model_id` reads the pk off the in-memory instance via `root.__dict__[id_attr]`. It only touches the DB in the deferred-field fallback, where it calls `django_getattr`, which is itself `django_resolver`-wrapped and already bridges sync/async on its own.

## Fix

Apply `django_resolver` only to `resolve_node`/`resolve_nodes`, and bind `resolve_id`/`resolve_id_attr` directly. `resolve_model_id` needs no change: it already returns the correct `AwaitableOrValue[str]`, a plain `str` on the fast path and an awaitable from `django_getattr` on the deferred path.

## Test

Added a regression test asserting that, inside a running event loop, `resolve_id` returns a plain `str` rather than a coroutine, for both default-pk and explicit-`NodeID` types. Against the old code it fails with `result` being a `SyncToAsync.__call__` coroutine.

## Summary by Sourcery

Avoid routing Relay node ID resolution through async thread hops and document the change as a patch release.

Bug Fixes:
- Prevent Relay node ID resolution from incurring unnecessary sync_to_async thread hops in async contexts.

Enhancements:
- Clarify relay ID resolver docstrings to describe synchronous in-memory ID access and deferred-field behavior.

Documentation:
- Add RELEASE notes describing the performance improvement to Relay node ID resolution.

Tests:
- Add a regression test ensuring resolve_id returns a plain string and not an awaitable when called inside an async context.