### PR TITLE
fix: call is_type_of methods in superclasses of Django GraphQL types

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+---
+release type: patch
+---
+
+`@strawberry_django.type` types no longer overwrite `is_type_of` methods in superclasses.
+Instead, the superclass' result will be taken into account as well.

--- a/strawberry_django/type.py
+++ b/strawberry_django/type.py
@@ -203,10 +203,14 @@ def _process_type(
     # Make sure model is also considered a "virtual subclass" of cls
     if "is_type_of" not in cls.__dict__:
 
-        def is_type_of(obj, info):
+        @classmethod
+        def is_type_of(virtual_cls, obj, info):
             if (type_cast := get_strawberry_type_cast(obj)) is not None:
                 return type_cast is cls
-            return isinstance(obj, (cls, model))
+            super_func = getattr(super(cls, virtual_cls), "is_type_of", None)
+            return (super_func is None or super_func(obj, info)) and isinstance(
+                obj, (cls, model)
+            )
 
         cls.is_type_of = is_type_of
 

--- a/tests/test_custom_is_type_of.py
+++ b/tests/test_custom_is_type_of.py
@@ -1,0 +1,144 @@
+import typing
+from typing import Any, cast
+
+import pytest
+import strawberry
+from graphql import GraphQLResolveInfo
+from strawberry.types.base import StrawberryObjectDefinition
+from strawberry.types.cast import cast as strawberry_cast
+
+import strawberry_django
+from tests.models import Fruit
+
+
+@strawberry_django.interface(Fruit)
+class FruitType:
+    name: str
+    sweetness: int
+
+    @classmethod
+    def is_type_of(cls, obj: Any, _info: GraphQLResolveInfo) -> bool:
+        if not isinstance(obj, Fruit):
+            return False
+        is_sweet = obj.sweetness >= 5
+        return (is_sweet and cls == SweetFruitType) or (
+            not is_sweet and cls == SourFruitType
+        )
+
+
+@strawberry_django.type(Fruit)
+class SweetFruitType(FruitType):
+    pass
+
+
+@strawberry_django.type(Fruit)
+class SourFruitType(FruitType):
+    pass
+
+
+@strawberry_django.interface(Fruit)
+class PlainFruitType:
+    name: str
+    sweetness: int
+
+
+@strawberry_django.type(Fruit)
+class DirectSourFruitType(PlainFruitType):
+    @classmethod
+    def is_type_of(cls, obj: Any, _info: GraphQLResolveInfo) -> bool:
+        return isinstance(obj, Fruit) and obj.sweetness < 5
+
+
+class TypeOfMixin:
+    @classmethod
+    def is_type_of(cls, obj: Any, _info: GraphQLResolveInfo) -> bool:
+        return isinstance(obj, Fruit) and obj.sweetness < 5
+
+
+@strawberry_django.type(Fruit)
+class MixinSourFruitType(TypeOfMixin, PlainFruitType):
+    pass
+
+
+@strawberry.type
+class Query:
+    @strawberry_django.field()
+    def fruits(self) -> list[SourFruitType | SweetFruitType]:
+        return typing.cast(
+            "list[SourFruitType | SweetFruitType]", Fruit.objects.all().order_by("name")
+        )
+
+
+@pytest.fixture
+def schema() -> strawberry.Schema:
+    return strawberry.Schema(
+        query=Query, types=(PlainFruitType, DirectSourFruitType, MixinSourFruitType)
+    )
+
+
+@pytest.fixture
+def mock_info() -> GraphQLResolveInfo:
+    return cast("GraphQLResolveInfo", object())
+
+
+def test_direct_is_type_of(schema, mock_info):
+    sour_fruit_type = schema.get_type_by_name("DirectSourFruitType")
+    assert isinstance(sour_fruit_type, StrawberryObjectDefinition)
+    assert sour_fruit_type.is_type_of is not None
+    assert sour_fruit_type.is_type_of(Fruit(name="x", sweetness=0), mock_info)
+    assert not sour_fruit_type.is_type_of(Fruit(name="x", sweetness=10), mock_info)
+
+
+def test_mixin_is_type_of(schema, mock_info):
+    sour_fruit_type = schema.get_type_by_name("MixinSourFruitType")
+    assert isinstance(sour_fruit_type, StrawberryObjectDefinition)
+    assert sour_fruit_type.is_type_of is not None
+    assert sour_fruit_type.is_type_of(Fruit(name="x", sweetness=0), mock_info)
+    assert not sour_fruit_type.is_type_of(Fruit(name="x", sweetness=10), mock_info)
+
+
+def test_inherited_is_type_of(schema, mock_info):
+    sour_fruit_type = schema.get_type_by_name("SourFruitType")
+    assert isinstance(sour_fruit_type, StrawberryObjectDefinition)
+    assert sour_fruit_type.is_type_of is not None
+    assert sour_fruit_type.is_type_of(Fruit(name="x", sweetness=0), mock_info)
+    assert not sour_fruit_type.is_type_of(Fruit(name="x", sweetness=10), mock_info)
+    assert not sour_fruit_type.is_type_of(object(), mock_info)
+
+
+def test_inherited_is_type_of_with_strawberry_type_cast(schema, mock_info):
+    sour_fruit_type = schema.get_type_by_name("SourFruitType")
+    sweet_fruit_type = schema.get_type_by_name("SweetFruitType")
+
+    assert isinstance(sour_fruit_type, StrawberryObjectDefinition)
+    assert isinstance(sweet_fruit_type, StrawberryObjectDefinition)
+    assert sour_fruit_type.is_type_of is not None
+
+    sweet_fruit = Fruit(name="x", sweetness=10)
+
+    assert sour_fruit_type.is_type_of(
+        strawberry_cast(SourFruitType, sweet_fruit), mock_info
+    )
+    assert not sour_fruit_type.is_type_of(
+        strawberry_cast(SweetFruitType, Fruit(name="y", sweetness=0)),
+        mock_info,
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_inherited_is_type_of_with_schema(schema):
+    Fruit.objects.create(name="Sour 1", sweetness=1)
+    Fruit.objects.create(name="Sweet 1", sweetness=10)
+    Fruit.objects.create(name="Sour 2", sweetness=2)
+    Fruit.objects.create(name="Sweet 2", sweetness=8)
+
+    result = schema.execute_sync("{ fruits { __typename ...on FruitType { name } } }")
+    assert result.errors is None
+    assert result.data == {
+        "fruits": [
+            {"__typename": "SourFruitType", "name": "Sour 1"},
+            {"__typename": "SourFruitType", "name": "Sour 2"},
+            {"__typename": "SweetFruitType", "name": "Sweet 1"},
+            {"__typename": "SweetFruitType", "name": "Sweet 2"},
+        ]
+    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Previously, any `strawberry_django.type` would unconditionally add an `is_type_of` method, which replaced any custom logic in parent classes.
This pull request improves the added `is_type_of` method to also call super().is_type_of.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes #919

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Ensure Django Strawberry types respect custom and inherited is_type_of logic while still handling model-based type resolution.

Bug Fixes:
- Preserve and invoke is_type_of implementations from superclasses for strawberry_django.type-generated GraphQL types instead of overwriting them.

Tests:
- Add integration-style tests covering custom, mixin-based, and inherited is_type_of implementations, including behavior with strawberry type casting and schema execution for Fruit-related types.