### PR TITLE
fix: honor DEFAULT_PK_FIELD_NAME in mutation instance lookups

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+---
+release type: patch
+---
+
+Honor the `DEFAULT_PK_FIELD_NAME` setting (and per-field `key_attr`) when
+resolving existing instances in mutation inputs. Previously `_parse_pk` read the
+input value under `key_attr` but always looked the instance up by `pk=`, so
+relation inputs and bare-id updates that reference an object by a configured
+non-pk field raised `DoesNotExist` or matched the wrong row. Filters already
+honored the setting; mutations now do too. The default `pk`-based path is
+unchanged.

--- a/strawberry_django/mutations/resolvers.py
+++ b/strawberry_django/mutations/resolvers.py
@@ -56,6 +56,20 @@ _T = TypeVar("_T")
 _M = TypeVar("_M", bound=Model)
 
 
+def _pk_lookup(model: type[Model], key_attr: str | None, value: Any) -> dict[str, Any]:
+    """Build the `get()` lookup that resolves an instance by its key.
+
+    Honors `DEFAULT_PK_FIELD_NAME` the same way filters do: when `key_attr`
+    names a non-pk field, look the instance up by that field; otherwise fall
+    back to `pk` so the default path stays byte-for-byte equivalent.
+    """
+    pk = model._meta.pk
+    assert pk is not None
+    if key_attr in (None, "pk", pk.name, pk.attname):  # noqa: PLR6201
+        return {"pk": value}
+    return {key_attr: value}
+
+
 def _parse_pk(
     value: ParsedObject | strawberry.ID | _M | None,
     model: type[_M],
@@ -79,11 +93,14 @@ def _parse_pk(
         if key_attr in value:
             obj_pk = value[key_attr]
             if obj_pk is not strawberry.UNSET:
-                return model._default_manager.get(pk=obj_pk), value
+                return (
+                    model._default_manager.get(**_pk_lookup(model, key_attr, obj_pk)),
+                    value,
+                )
 
         return None, value
 
-    return model._default_manager.get(pk=value), None
+    return model._default_manager.get(**_pk_lookup(model, key_attr, value)), None
 
 
 def _parse_data(

--- a/tests/models.py
+++ b/tests/models.py
@@ -143,3 +143,10 @@ except ImproperlyConfigured:
 class UUIDModel(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     text = models.CharField(max_length=50)
+
+
+class NonIdPkModel(models.Model):
+    # Primary key field is deliberately *not* named ``id``/``pk`` so tests can
+    # exercise the ``pk.name``/``pk.attname`` branch of ``_pk_lookup``.
+    code = models.CharField(primary_key=True, max_length=50)
+    text = models.CharField(max_length=50)

--- a/tests/mutations/test_parse_pk.py
+++ b/tests/mutations/test_parse_pk.py
@@ -29,7 +29,7 @@ def colors(db):
 def test_parse_pk_dict_by_non_pk_key(colors):
     """A dict input under a non-pk `key_attr` looks the instance up by that field."""
     red, _ = colors
-    obj, data = resolvers._parse_pk({"name": "red"}, models.Color, key_attr="name")
+    obj, data = resolvers._parse_pk({"name": "red"}, models.Color, key_attr="name")  # pyright: ignore[reportArgumentType]
     assert obj == red
     assert data == {"name": "red"}
 
@@ -37,7 +37,7 @@ def test_parse_pk_dict_by_non_pk_key(colors):
 def test_parse_pk_bare_value_by_non_pk_key(colors):
     """A bare value with a non-pk `key_attr` looks the instance up by that field."""
     _, blue = colors
-    obj, data = resolvers._parse_pk("blue", models.Color, key_attr="name")
+    obj, data = resolvers._parse_pk("blue", models.Color, key_attr="name")  # pyright: ignore[reportArgumentType]
     assert obj == blue
     assert data is None
 
@@ -49,7 +49,8 @@ def test_parse_pk_non_pk_key_does_not_fall_back_to_pk(colors):
     ``DoesNotExist`` instead of resolving by name.
     """
     red, _ = colors
-    obj, _data = resolvers._parse_pk({"name": "red"}, models.Color, key_attr="name")
+    obj, _data = resolvers._parse_pk({"name": "red"}, models.Color, key_attr="name")  # pyright: ignore[reportArgumentType]
+    assert obj is not None
     assert obj.pk == red.pk
 
 
@@ -64,11 +65,57 @@ def test_parse_pk_default_path_uses_pk(colors, key_attr):
     dict_key = key_attr or "pk"
     # dict branch
     obj, data = resolvers._parse_pk(
-        {dict_key: blue.pk}, models.Color, key_attr=key_attr
+        {dict_key: blue.pk},  # pyright: ignore[reportArgumentType]
+        models.Color,
+        key_attr=key_attr,
     )
     assert obj == blue
     assert data == {dict_key: blue.pk}
     # bare-value branch
     obj, data = resolvers._parse_pk(red.pk, models.Color, key_attr=key_attr)
     assert obj == red
+    assert data is None
+
+
+@pytest.mark.parametrize("key_attr", [None, "pk", "code"])
+def test_pk_lookup_non_id_pk_routes_to_pk(key_attr):
+    """A `key_attr` naming a non-`id` primary key still routes via `pk=`.
+
+    `NonIdPkModel`'s primary key is the `code` field. `_pk_lookup` only reads
+    `model._meta.pk` (no DB), so we can assert the lookup dict directly. This is
+    the part the object-equality tests can't see: `get(pk=v)` and `get(code=v)`
+    resolve the same row, so only inspecting the dict proves we kept the `pk=`
+    key for the default path instead of `{code: v}`.
+    """
+    assert resolvers._pk_lookup(models.NonIdPkModel, key_attr, "x") == {"pk": "x"}
+
+
+def test_pk_lookup_non_pk_key_keeps_that_field():
+    """A `key_attr` that is *not* the primary key looks up by that field."""
+    assert resolvers._pk_lookup(models.NonIdPkModel, "text", "x") == {"text": "x"}
+
+
+@pytest.fixture
+def coded(db):
+    a = models.NonIdPkModel.objects.create(code="a", text="alpha")
+    b = models.NonIdPkModel.objects.create(code="b", text="beta")
+    return a, b
+
+
+@pytest.mark.parametrize("key_attr", [None, "pk", "code"])
+def test_parse_pk_non_id_pk_default_path_uses_pk(coded, key_attr):
+    """Models with a non-`id` primary key still resolve via `pk` end to end."""
+    a, b = coded
+    dict_key = key_attr or "pk"
+    # dict branch
+    obj, data = resolvers._parse_pk(
+        {dict_key: b.pk},  # pyright: ignore[reportArgumentType]
+        models.NonIdPkModel,
+        key_attr=key_attr,
+    )
+    assert obj == b
+    assert data == {dict_key: b.pk}
+    # bare-value branch
+    obj, data = resolvers._parse_pk(a.pk, models.NonIdPkModel, key_attr=key_attr)
+    assert obj == a
     assert data is None

--- a/tests/mutations/test_parse_pk.py
+++ b/tests/mutations/test_parse_pk.py
@@ -1,0 +1,74 @@
+"""Regression tests for `_parse_pk` honoring `DEFAULT_PK_FIELD_NAME`.
+
+`_parse_pk` reads a mutation input under `key_attr` (defaulting to the
+`DEFAULT_PK_FIELD_NAME` setting), but it used to always look the instance up by
+`pk=`, ignoring `key_attr`. When `DEFAULT_PK_FIELD_NAME` names a non-pk field,
+`update` and relation-by-field inputs then queried `get(pk=<value-of-the-field>)`
+and raised `DoesNotExist` / matched the wrong row. Filters already honor the
+setting; these tests pin the same behavior for mutations.
+
+Regression test for https://github.com/strawberry-graphql/strawberry-django/issues/927
+"""
+
+import pytest
+
+from strawberry_django.mutations import resolvers
+from tests import models
+
+
+@pytest.fixture
+def colors(db):
+    # ``pk`` and ``name`` are deliberately misaligned so a lookup by the wrong
+    # field resolves a different row (or none), surfacing the bug.
+    red = models.Color.objects.create(name="red")
+    blue = models.Color.objects.create(name="blue")
+    assert red.pk != blue.pk
+    return red, blue
+
+
+def test_parse_pk_dict_by_non_pk_key(colors):
+    """A dict input under a non-pk `key_attr` looks the instance up by that field."""
+    red, _ = colors
+    obj, data = resolvers._parse_pk({"name": "red"}, models.Color, key_attr="name")
+    assert obj == red
+    assert data == {"name": "red"}
+
+
+def test_parse_pk_bare_value_by_non_pk_key(colors):
+    """A bare value with a non-pk `key_attr` looks the instance up by that field."""
+    _, blue = colors
+    obj, data = resolvers._parse_pk("blue", models.Color, key_attr="name")
+    assert obj == blue
+    assert data is None
+
+
+def test_parse_pk_non_pk_key_does_not_fall_back_to_pk(colors):
+    """A non-pk `key_attr` must query that field, never `pk=`.
+
+    Before the fix this queried ``get(pk="red")`` and raised ``ValueError`` /
+    ``DoesNotExist`` instead of resolving by name.
+    """
+    red, _ = colors
+    obj, _data = resolvers._parse_pk({"name": "red"}, models.Color, key_attr="name")
+    assert obj.pk == red.pk
+
+
+@pytest.mark.parametrize("key_attr", [None, "pk", "id"])
+def test_parse_pk_default_path_uses_pk(colors, key_attr):
+    """The pk path stays byte-for-byte equivalent: `pk`/`id` resolve by `pk`.
+
+    `id` is the primary key of `Color`, so it must map to a `pk=` lookup; `None`
+    falls back to the `DEFAULT_PK_FIELD_NAME` default of `pk`.
+    """
+    red, blue = colors
+    dict_key = key_attr or "pk"
+    # dict branch
+    obj, data = resolvers._parse_pk(
+        {dict_key: blue.pk}, models.Color, key_attr=key_attr
+    )
+    assert obj == blue
+    assert data == {dict_key: blue.pk}
+    # bare-value branch
+    obj, data = resolvers._parse_pk(red.pk, models.Color, key_attr=key_attr)
+    assert obj == red
+    assert data is None


### PR DESCRIPTION
Fixes #927.

`_parse_pk` resolved mutation input instances with
`model._default_manager.get(pk=…)` even when `key_attr` (defaulting to the
`DEFAULT_PK_FIELD_NAME` setting) named a non-pk field. Filters already honor the
setting, but mutations did not — so relation inputs (and the bare-id path) that
reference an existing object by the configured field looked the row up by `pk`
with the wrong value, raising `DoesNotExist` / `ValueError`.

This adds a `_pk_lookup` helper that builds the lookup from `key_attr`:
`{key_attr: value}` for a non-pk field, falling back to `{"pk": value}` when
`key_attr` is `None` / `"pk"` / the pk's `name` / `attname` — so the default path
is byte-for-byte equivalent. Applied at both `get()` sites in `_parse_pk`.

### Tests
- New `tests/mutations/test_parse_pk.py` (regression): non-pk-key lookups resolve
  by the configured field; the default-pk path is unchanged. Verified it fails on
  unfixed code (`get(pk='red')` → `ValueError`) and passes with the fix.
- Full suite: **1194 passed, 11 skipped, 0 failed**. `ruff` lint + format clean.

## Summary by Sourcery

Honor the configured primary key field name when resolving instances in mutation input parsing.

Bug Fixes:
- Ensure `_parse_pk` resolves mutation inputs using the configured key attribute (e.g. `DEFAULT_PK_FIELD_NAME`) instead of always querying by the model `pk`.

Tests:
- Add regression tests verifying `_parse_pk` looks up instances by non-pk key attributes and that the default pk-based behavior remains unchanged.