### PR TITLE
fix: skip the per-parent COUNT for totalCount of empty prefetched nested connections

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: patch
+
+Fix an N+1 on `totalCount` of nested connections optimized by prefetching:
+parents whose prefetched first-page partition came back empty issued one
+`COUNT(*)` query each, even though an empty first page already proves the
+total count is 0.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,6 @@
-Release type: patch
+---
+release type: patch
+---
 
 Fix an N+1 on `totalCount` of nested connections optimized by prefetching:
 parents whose prefetched first-page partition came back empty issued one

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -355,18 +355,34 @@ def get_total_count(queryset: QuerySet) -> int:
 def _is_non_empty_first_page_window(queryset: QuerySet) -> bool:
     """Whether the window pagination on ``queryset`` selects a first page that can hold at least one row.
 
-    True when there is no window offset filter (``row_number > offset``) and the
-    window limit filter (``row_number <= limit``), if any, admits at least one row.
-    For such a page, no results implies an empty partition.
+    `apply_window_pagination` expresses pagination exclusively as `gt` (offset)
+    and `lte` (offset + limit) filters against its `_PaginationWindow` row
+    numbers. Those row numbers are computed over the queryset with all of its
+    other filters already applied, so a page with no offset and room for at
+    least one row (every `lte` bound is >= 1) coming back empty proves that
+    `remove_window_pagination(queryset).count()` would return 0.
+
+    Any other filter shape on a `_PaginationWindow` is not produced by
+    `apply_window_pagination`; be conservative and report False for it so
+    callers fall back to counting.
     """
     for child in queryset.query.where.children:
         if not isinstance(getattr(child, "lhs", None), _PaginationWindow):
             continue
-        lookup_name = getattr(child, "lookup_name", None)
-        if lookup_name == "gt":
+
+        if getattr(child, "lookup_name", None) != "lte":
+            # A `gt` filter means an offset was applied: an empty page past
+            # the end says nothing about the partition size. Anything else is
+            # an unrecognized shape we can't reason about.
             return False
-        if lookup_name == "lte" and not getattr(child, "rhs", None):
+
+        rhs = getattr(child, "rhs", None)
+        if not isinstance(rhs, int) or rhs < 1:
+            # A zero-sized page (limit 0) is empty even for non-empty
+            # partitions; a missing or non-integer bound is an unrecognized
+            # shape we can't reason about.
             return False
+
     return True
 
 

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -338,12 +338,36 @@ def get_total_count(queryset: QuerySet) -> int:
                     stacklevel=2,
                 )
 
+        elif results is not None and _is_non_empty_first_page_window(queryset):
+            # An empty first page (no offset, limit >= 1) can only come from an
+            # empty partition, so there is nothing to count. This avoids one
+            # COUNT query per parent without results in nested connections.
+            return 0
+
         # If we have no results, we can't get the total count from the cache.
         # In this case we will remove the pagination filter to be able to `.count()`
         # the whole queryset with its original filters.
         queryset = remove_window_pagination(queryset)
 
     return queryset.count()
+
+
+def _is_non_empty_first_page_window(queryset: QuerySet) -> bool:
+    """Whether the window pagination on ``queryset`` selects a first page that can hold at least one row.
+
+    True when there is no window offset filter (``row_number > offset``) and the
+    window limit filter (``row_number <= limit``), if any, admits at least one row.
+    For such a page, no results implies an empty partition.
+    """
+    for child in queryset.query.where.children:
+        if not isinstance(getattr(child, "lhs", None), _PaginationWindow):
+            continue
+        lookup_name = getattr(child, "lookup_name", None)
+        if lookup_name == "gt":
+            return False
+        if lookup_name == "lte" and not getattr(child, "rhs", None):
+            return False
+    return True
 
 
 class StrawberryDjangoPagination(StrawberryDjangoFieldBase):

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -365,7 +365,18 @@ def _is_non_empty_first_page_window(queryset: QuerySet) -> bool:
     Any other filter shape on a `_PaginationWindow` is not produced by
     `apply_window_pagination`; be conservative and report False for it so
     callers fall back to counting.
+
+    Note that no window *filters* at all is a valid first-page shape: an
+    offset of 0 with no limit fetches whole partitions, filterless. What must
+    be present are the `_PaginationWindow` *annotations*, proving the queryset
+    went through `apply_window_pagination` in the first place.
     """
+    if not any(
+        isinstance(annotation, _PaginationWindow)
+        for annotation in queryset.query.annotations.values()
+    ):
+        return False
+
     for child in queryset.query.where.children:
         if not isinstance(getattr(child, "lhs", None), _PaginationWindow):
             continue

--- a/tests/relay/test_cursor_pagination.py
+++ b/tests/relay/test_cursor_pagination.py
@@ -1389,6 +1389,68 @@ def test_nested_total_count():
 
 
 @pytest.mark.django_db(transaction=True)
+def test_nested_total_count_with_empty_partitions():
+    p1 = Project.objects.create()
+    p2 = Project.objects.create()
+    p3 = Project.objects.create()
+
+    p1m = [Milestone.objects.create(project=p1) for _ in range(3)]
+
+    query = """
+    query TestQuery {
+        projects(first: 3, order: { id: ASC }) {
+            edges {
+              node {
+                id
+                milestones { totalCount edges { node { id } } }
+              }
+            }
+        }
+    }
+    """
+    # An empty prefetched first-page partition proves the total count is 0;
+    # projects without milestones must not each fall back to a COUNT query.
+    with assert_num_queries(2):
+        result = schema.execute_sync(query)
+        assert result.data == {
+            "projects": {
+                "edges": [
+                    {
+                        "node": {
+                            "id": str(GlobalID("ProjectType", str(p1.pk))),
+                            "milestones": {
+                                "totalCount": 3,
+                                "edges": [
+                                    {
+                                        "node": {
+                                            "id": str(
+                                                GlobalID("MilestoneType", str(m.pk))
+                                            )
+                                        }
+                                    }
+                                    for m in p1m
+                                ],
+                            },
+                        }
+                    },
+                    {
+                        "node": {
+                            "id": str(GlobalID("ProjectType", str(p2.pk))),
+                            "milestones": {"totalCount": 0, "edges": []},
+                        }
+                    },
+                    {
+                        "node": {
+                            "id": str(GlobalID("ProjectType", str(p3.pk))),
+                            "milestones": {"totalCount": 0, "edges": []},
+                        }
+                    },
+                ],
+            }
+        }
+
+
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize(
     "cursor",
     [

--- a/tests/relay/test_cursor_pagination.py
+++ b/tests/relay/test_cursor_pagination.py
@@ -1451,6 +1451,52 @@ def test_nested_total_count_with_empty_partitions():
 
 
 @pytest.mark.django_db(transaction=True)
+def test_nested_total_count_with_first_zero():
+    p1 = Project.objects.create()
+    p2 = Project.objects.create()
+
+    for _ in range(3):
+        Milestone.objects.create(project=p1)
+
+    query = """
+    query TestQuery {
+        projects(first: 2, order: { id: ASC }) {
+            edges {
+              node {
+                id
+                milestones(first: 0) { totalCount edges { node { id } } }
+              }
+            }
+        }
+    }
+    """
+    # `first: 0` pages are always empty and must not be mistaken for empty
+    # partitions: the total count must still be resolved correctly. Cursor
+    # connections overfetch one row for `hasNextPage`, so the window keeps
+    # carrying the total count annotation and no COUNT queries are needed.
+    with assert_num_queries(2):
+        result = schema.execute_sync(query)
+        assert result.data == {
+            "projects": {
+                "edges": [
+                    {
+                        "node": {
+                            "id": str(GlobalID("ProjectType", str(p1.pk))),
+                            "milestones": {"totalCount": 3, "edges": []},
+                        }
+                    },
+                    {
+                        "node": {
+                            "id": str(GlobalID("ProjectType", str(p2.pk))),
+                            "milestones": {"totalCount": 0, "edges": []},
+                        }
+                    },
+                ],
+            }
+        }
+
+
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize(
     "cursor",
     [

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -803,6 +803,57 @@ def test_query_connection_nested_total_count_with_offset_past_end(
 
 
 @pytest.mark.django_db(transaction=True)
+def test_query_connection_nested_total_count_with_first_zero(
+    db, gql_client: GraphQLTestClient
+):
+    query = """
+      query TestQuery {
+        tagList {
+          id
+          name
+          issues (first: 0) {
+            totalCount
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    t1 = TagFactory.create()
+    t2 = TagFactory.create()
+
+    t1_issues = IssueFactory.create_batch(3)
+    for issue in t1_issues:
+        t1.issues.add(issue)
+
+    # A zero-sized page is empty regardless of the partition size, so the
+    # total count cannot be derived from it and must still be queried,
+    # once per tag.
+    with assert_num_queries(4 if DjangoOptimizerExtension.enabled.get() else 5):
+        res = gql_client.query(query)
+
+    assert res.data == {
+        "tagList": [
+            {
+                "id": to_base64("TagType", t1.id),
+                "name": t1.name,
+                "issues": {"totalCount": 3, "edges": []},
+            },
+            {
+                "id": to_base64("TagType", t2.id),
+                "name": t2.name,
+                "issues": {"totalCount": 0, "edges": []},
+            },
+        ],
+    }
+
+
+@pytest.mark.django_db(transaction=True)
 def test_query_nested_fragments(db, gql_client: GraphQLTestClient):
     query = """
       query TestQuery {

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -697,6 +697,112 @@ def test_query_connection_nested(db, gql_client: GraphQLTestClient):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_query_connection_nested_total_count_with_empty_partitions(
+    db, gql_client: GraphQLTestClient
+):
+    query = """
+      query TestQuery {
+        tagList {
+          id
+          name
+          issues (first: 2) {
+            totalCount
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    t1 = TagFactory.create()
+    t2 = TagFactory.create()
+    t3 = TagFactory.create()
+
+    t1_issues = IssueFactory.create_batch(3)
+    for issue in t1_issues:
+        t1.issues.add(issue)
+
+    # Tags without issues have an empty prefetched first-page partition, which
+    # proves their total count is 0 - they must not fall back to a COUNT each.
+    with assert_num_queries(2 if DjangoOptimizerExtension.enabled.get() else 7):
+        res = gql_client.query(query)
+
+    assert res.data == {
+        "tagList": [
+            {
+                "id": to_base64("TagType", t1.id),
+                "name": t1.name,
+                "issues": {
+                    "totalCount": 3,
+                    "edges": [
+                        {"node": {"id": to_base64("IssueType", t.id), "name": t.name}}
+                        for t in t1_issues[:2]
+                    ],
+                },
+            },
+            {
+                "id": to_base64("TagType", t2.id),
+                "name": t2.name,
+                "issues": {"totalCount": 0, "edges": []},
+            },
+            {
+                "id": to_base64("TagType", t3.id),
+                "name": t3.name,
+                "issues": {"totalCount": 0, "edges": []},
+            },
+        ],
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_query_connection_nested_total_count_with_offset_past_end(
+    db, gql_client: GraphQLTestClient
+):
+    query = """
+      query TestQuery ($after: String) {
+        tagList {
+          id
+          name
+          issues (first: 2, after: $after) {
+            totalCount
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    t1 = TagFactory.create()
+
+    t1_issues = IssueFactory.create_batch(3)
+    for issue in t1_issues:
+        t1.issues.add(issue)
+
+    # A page past the end is empty even though the partition is not: the total
+    # count cannot be derived from the empty page and must still be queried.
+    with assert_num_queries(3):
+        res = gql_client.query(query, {"after": to_base64("arrayconnection", "9")})
+
+    assert res.data == {
+        "tagList": [
+            {
+                "id": to_base64("TagType", t1.id),
+                "name": t1.name,
+                "issues": {"totalCount": 3, "edges": []},
+            },
+        ],
+    }
+
+
+@pytest.mark.django_db(transaction=True)
 def test_query_nested_fragments(db, gql_client: GraphQLTestClient):
     query = """
       query TestQuery {

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -11,6 +11,7 @@ import strawberry_django
 from strawberry_django.optimizer import DjangoOptimizerExtension
 from strawberry_django.pagination import (
     OffsetPaginationInput,
+    _is_non_empty_first_page_window,  # noqa: PLC2701
     apply,
     apply_window_pagination,
 )
@@ -129,6 +130,40 @@ def test_apply_window_pagination():
     assert fruit.name == "fruit1"
     assert fruit._strawberry_row_number == 2  # type: ignore
     assert fruit._strawberry_total_count == 10  # type: ignore
+
+
+@pytest.mark.parametrize(
+    ("offset", "limit", "expected"),
+    [
+        # First pages with room for at least one row: an empty result cache
+        # can only come from an empty partition.
+        (0, 1, True),
+        (0, 10, True),
+        (0, -1, True),  # no limit: whole partitions are fetched, filterless
+        (0, sys.maxsize, True),  # relay's "no limit" sentinel
+        # Pages that can be empty for non-empty partitions.
+        (1, 10, False),  # offset: the page may simply be past the end
+        (0, 0, False),  # zero-sized page
+    ],
+)
+def test_is_non_empty_first_page_window(offset, limit, expected):
+    queryset = apply_window_pagination(
+        models.Fruit.objects.all(),
+        related_field_id="color_id",
+        offset=offset,
+        limit=limit,
+    )
+
+    assert _is_non_empty_first_page_window(queryset) is expected
+
+
+def test_is_non_empty_first_page_window_without_window_pagination():
+    # A queryset that never went through apply_window_pagination proves
+    # nothing about its partition, whatever its filters.
+    assert not _is_non_empty_first_page_window(models.Fruit.objects.all())
+    assert not _is_non_empty_first_page_window(
+        models.Fruit.objects.filter(name="strawberry")
+    )
 
 
 @pytest.mark.parametrize("limit", [-1, sys.maxsize])


### PR DESCRIPTION
When a nested connection is optimized by prefetching, totalCount is read from the _strawberry_total_count window annotation on the fetched rows. Parents with no matching rows have nothing to read the annotation from, so get_total_count fell back to one real COUNT query per such parent — an N+1 that grows with the number of childless parents.

For a first-page window (no row_number offset filter and a limit that admits at least one row), an empty partition can only mean the filtered set is empty, so totalCount is 0 without querying. Pages past the end (offset > 0) and first: 0 pages still fall back to COUNT, since there the empty page proves nothing.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Avoid unnecessary COUNT queries when resolving totalCount for empty prefetched nested connections.

Bug Fixes:
- Ensure totalCount for nested connections with empty prefetched partitions is correctly resolved as 0 without issuing per-parent COUNT queries.

Enhancements:
- Add logic to detect non-empty first-page window pagination and infer zero totalCount from empty result sets to prevent N+1 COUNT queries in nested connections.

Documentation:
- Add RELEASE notes describing the patch-level fix for nested connection totalCount N+1 issues.

Tests:
- Add regression tests covering totalCount behavior for nested connections with empty partitions, offsets past the end, and first: 0 pages in both Django optimizer and relay cursor pagination flows.