### PR TITLE
perf: resolve prefetch-optimized nested connections without per-node thread hops

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+Resolve prefetch-optimized nested connections on the event loop instead of
+paying a `sync_to_async` thread hop per parent node: the nested-connection
+default resolver, the queryset hook for prefetch-optimized querysets and
+`totalCount` served from the prefetched window annotation no longer touch
+the database, so they no longer need a worker thread.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,6 @@
-Release type: patch
+---
+release type: patch
+---
 
 Resolve prefetch-optimized nested connections on the event loop instead of
 paying a `sync_to_async` thread hop per parent node: the nested-connection

--- a/strawberry_django/fields/base.py
+++ b/strawberry_django/fields/base.py
@@ -171,7 +171,11 @@ class StrawberryDjangoFieldBase(StrawberryField):
         resolver = self.base_resolver
         assert resolver
 
-        if not resolver.is_async:
+        # Library-internal resolvers marked `is_async_safe` never run a query
+        # themselves, so they can skip the sync_to_async thread hop entirely.
+        if not resolver.is_async and not getattr(
+            resolver.wrapped_func, "is_async_safe", False
+        ):
             resolver = django_resolver(resolver, qs_hook=None)
 
         return resolver

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -42,6 +42,7 @@ from strawberry.types.field import _RESOLVER_TYPE  # noqa: PLC2701
 from strawberry.types.fields.resolver import StrawberryResolver
 from strawberry.types.info import Info
 from strawberry.utils.await_maybe import await_maybe
+from strawberry.utils.inspect import in_async_context
 
 from strawberry_django import optimizer
 from strawberry_django.arguments import argument
@@ -289,9 +290,17 @@ class StrawberryDjangoField(
                     if "info" not in kwargs:
                         kwargs["info"] = info
 
-                    resolved = await sync_to_async(self.get_queryset_hook(**kwargs))(
-                        resolved
-                    )
+                    qs_hook = self.get_queryset_hook(**kwargs)
+                    if (
+                        resolved._result_cache is not None  # type: ignore
+                        and is_optimized_by_prefetching(resolved)
+                    ):
+                        # The prefetched results are already in memory and
+                        # get_queryset short-circuits for prefetch-optimized
+                        # querysets, so the hook does no database work.
+                        resolved = qs_hook(resolved)
+                    else:
+                        resolved = await sync_to_async(qs_hook)(resolved)
 
                 return resolved
 
@@ -304,10 +313,20 @@ class StrawberryDjangoField(
             if "info" not in kwargs:
                 kwargs["info"] = info
 
-            result = django_resolver(
-                self.get_queryset_hook(**kwargs),
-                qs_hook=lambda qs: qs,
-            )(result)
+            qs_hook = self.get_queryset_hook(**kwargs)
+            if (
+                result._result_cache is not None  # type: ignore
+                and is_optimized_by_prefetching(result)
+            ):
+                # The prefetched results are already in memory and get_queryset
+                # short-circuits for prefetch-optimized querysets, so the hook
+                # does no database work.
+                result = qs_hook(result)
+            else:
+                result = django_resolver(
+                    qs_hook,
+                    qs_hook=lambda qs: qs,
+                )(result)
 
         return result
 
@@ -450,7 +469,10 @@ class StrawberryDjangoConnectionExtension(relay.ConnectionExtension):
 
                 if root is not None:
                     # If this is a nested field, call get_result instead because we want
-                    # to retrieve the queryset from its RelatedManager
+                    # to retrieve the queryset from its RelatedManager. Accessing the
+                    # manager and calling `.all()` builds the queryset without
+                    # evaluating it (for prefetched relations it returns the cached
+                    # queryset), so this is safe to run on the event loop.
                     retval = cast(
                         "models.QuerySet",
                         getattr(root, field.django_name or field.python_name).all(),
@@ -464,15 +486,28 @@ class StrawberryDjangoConnectionExtension(relay.ConnectionExtension):
                             " each of those",
                         )
 
-                    retval = resolve_model_nodes(
-                        django_type,
-                        info=info,
-                        required=True,
-                    )
+                    # resolve_model_nodes may run user-defined `get_queryset`,
+                    # which is allowed to touch the database - keep it out of
+                    # the event loop.
+                    if in_async_context():
+                        retval = sync_to_async(resolve_model_nodes)(
+                            django_type,
+                            info=info,
+                            required=True,
+                        )
+                    else:
+                        retval = resolve_model_nodes(
+                            django_type,
+                            info=info,
+                            required=True,
+                        )
 
                 return cast("Iterable[Any]", retval)
 
             default_resolver.can_optimize = True  # type: ignore
+            # The resolver never runs a query itself (see the comments above),
+            # so it doesn't need the sync_to_async wrapping in async contexts.
+            default_resolver.is_async_safe = True  # type: ignore
 
             field.base_resolver = StrawberryResolver(default_resolver)
 

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -96,21 +96,6 @@ if TYPE_CHECKING:
 _T = TypeVar("_T")
 
 
-def _can_run_qs_hook_inline(queryset: models.QuerySet) -> bool:
-    """Whether the queryset hook can run without touching the database.
-
-    A queryset's `_result_cache` is either `None` or the fully evaluated row
-    list (Django populates it atomically in `_fetch_all`), so a non-None cache
-    means every row is already in memory. When such a queryset is also
-    prefetch-optimized, `get_queryset` short-circuits and the hook does no
-    database work, making it safe to run on the event loop.
-    """
-    return (
-        queryset._result_cache is not None  # type: ignore
-        and is_optimized_by_prefetching(queryset)
-    )
-
-
 class StrawberryDjangoField(
     StrawberryDjangoPagination,
     StrawberryDjangoFieldOrdering,
@@ -306,7 +291,7 @@ class StrawberryDjangoField(
                         kwargs["info"] = info
 
                     qs_hook = self.get_queryset_hook(**kwargs)
-                    if _can_run_qs_hook_inline(resolved):
+                    if self._can_run_qs_hook_inline(resolved):
                         resolved = qs_hook(resolved)
                     else:
                         resolved = await sync_to_async(qs_hook)(resolved)
@@ -323,7 +308,7 @@ class StrawberryDjangoField(
                 kwargs["info"] = info
 
             qs_hook = self.get_queryset_hook(**kwargs)
-            if _can_run_qs_hook_inline(result):
+            if self._can_run_qs_hook_inline(result):
                 result = qs_hook(result)
             else:
                 result = django_resolver(
@@ -400,6 +385,38 @@ class StrawberryDjangoField(
             queryset = ext.optimize(queryset, info=info)
 
         return queryset
+
+    def _can_run_qs_hook_inline(self, queryset: models.QuerySet) -> bool:
+        """Whether the queryset hook can run without touching the database.
+
+        Only hooks made purely of library code known to do in-memory work may
+        skip the sync_to_async thread hop and run on the event loop:
+
+        - Only the library's own `get_queryset` is guaranteed to short-circuit
+          for prefetch-optimized querysets before any user code (the type's
+          `get_queryset`, permissions, filters, ordering, pagination) runs. A
+          subclass override may hit the database, so it keeps its thread.
+        - The optional-object hook branch (see `get_queryset_hook`) resolves
+          via `QuerySet.first()`, which clones the queryset - dropping its
+          result cache - when it has no explicit ordering, and may therefore
+          still run a query.
+        - A queryset's `_result_cache` is either `None` or the fully evaluated
+          row list (Django populates it atomically in `_fetch_all`), so a
+          non-None cache on a prefetch-optimized queryset means every row is
+          already in memory.
+        """
+        if type(self).get_queryset is not StrawberryDjangoField.get_queryset:
+            return False
+
+        if self.is_optional and not (
+            self.is_connection or self.is_paginated or self.is_list
+        ):
+            return False
+
+        return (
+            queryset._result_cache is not None  # type: ignore
+            and is_optimized_by_prefetching(queryset)
+        )
 
 
 def _get_field_arguments_for_extensions(

--- a/strawberry_django/fields/field.py
+++ b/strawberry_django/fields/field.py
@@ -96,6 +96,21 @@ if TYPE_CHECKING:
 _T = TypeVar("_T")
 
 
+def _can_run_qs_hook_inline(queryset: models.QuerySet) -> bool:
+    """Whether the queryset hook can run without touching the database.
+
+    A queryset's `_result_cache` is either `None` or the fully evaluated row
+    list (Django populates it atomically in `_fetch_all`), so a non-None cache
+    means every row is already in memory. When such a queryset is also
+    prefetch-optimized, `get_queryset` short-circuits and the hook does no
+    database work, making it safe to run on the event loop.
+    """
+    return (
+        queryset._result_cache is not None  # type: ignore
+        and is_optimized_by_prefetching(queryset)
+    )
+
+
 class StrawberryDjangoField(
     StrawberryDjangoPagination,
     StrawberryDjangoFieldOrdering,
@@ -291,13 +306,7 @@ class StrawberryDjangoField(
                         kwargs["info"] = info
 
                     qs_hook = self.get_queryset_hook(**kwargs)
-                    if (
-                        resolved._result_cache is not None  # type: ignore
-                        and is_optimized_by_prefetching(resolved)
-                    ):
-                        # The prefetched results are already in memory and
-                        # get_queryset short-circuits for prefetch-optimized
-                        # querysets, so the hook does no database work.
+                    if _can_run_qs_hook_inline(resolved):
                         resolved = qs_hook(resolved)
                     else:
                         resolved = await sync_to_async(qs_hook)(resolved)
@@ -314,13 +323,7 @@ class StrawberryDjangoField(
                 kwargs["info"] = info
 
             qs_hook = self.get_queryset_hook(**kwargs)
-            if (
-                result._result_cache is not None  # type: ignore
-                and is_optimized_by_prefetching(result)
-            ):
-                # The prefetched results are already in memory and get_queryset
-                # short-circuits for prefetch-optimized querysets, so the hook
-                # does no database work.
+            if _can_run_qs_hook_inline(result):
                 result = qs_hook(result)
             else:
                 result = django_resolver(

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -340,6 +340,11 @@ def get_cached_total_count(queryset: QuerySet) -> int | None:
     if not is_optimized_by_prefetching(queryset):
         return None
 
+    # `_result_cache` is either None or the fully evaluated row list (Django
+    # populates it atomically in `_fetch_all`), so a truthy cache means every
+    # row of the windowed prefetch query is in memory. All rows carry the same
+    # window annotations, so the first row is representative; the
+    # AttributeError fallback below covers rows that lack them.
     results = queryset._result_cache  # type: ignore
     if not results:
         return None

--- a/strawberry_django/pagination.py
+++ b/strawberry_django/pagination.py
@@ -315,35 +315,53 @@ def get_total_count(queryset: QuerySet) -> int:
     """
     from strawberry_django.optimizer import is_optimized_by_prefetching
 
+    total_count = get_cached_total_count(queryset)
+    if total_count is not None:
+        return total_count
+
     if is_optimized_by_prefetching(queryset):
-        results = queryset._result_cache  # type: ignore
-
-        if results:
-            # If the queryset has DISTINCT enabled, the _strawberry_total_count
-            # annotation won't be accurate because window functions are evaluated
-            # before DISTINCT in SQL. Fall back to queryset.count() instead.
-            if queryset.query.distinct:
-                queryset = remove_window_pagination(queryset)
-                return queryset.count()
-
-            try:
-                return results[0]._strawberry_total_count
-            except AttributeError:
-                warnings.warn(
-                    (
-                        "Pagination annotations not found, falling back to QuerySet resolution. "
-                        "This might cause n+1 issues..."
-                    ),
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
-
         # If we have no results, we can't get the total count from the cache.
         # In this case we will remove the pagination filter to be able to `.count()`
         # the whole queryset with its original filters.
         queryset = remove_window_pagination(queryset)
 
     return queryset.count()
+
+
+def get_cached_total_count(queryset: QuerySet) -> int | None:
+    """Get the total count from the prefetched window annotation, without running any query.
+
+    Returns None when the count cannot be determined without hitting the
+    database; callers should then fall back to `get_total_count`, deferring
+    it to a thread when running in an async context.
+    """
+    from strawberry_django.optimizer import is_optimized_by_prefetching
+
+    if not is_optimized_by_prefetching(queryset):
+        return None
+
+    results = queryset._result_cache  # type: ignore
+    if not results:
+        return None
+
+    # If the queryset has DISTINCT enabled, the _strawberry_total_count
+    # annotation won't be accurate because window functions are evaluated
+    # before DISTINCT in SQL. Fall back to queryset.count() instead.
+    if queryset.query.distinct:
+        return None
+
+    try:
+        return results[0]._strawberry_total_count
+    except AttributeError:
+        warnings.warn(
+            (
+                "Pagination annotations not found, falling back to QuerySet resolution. "
+                "This might cause n+1 issues..."
+            ),
+            RuntimeWarning,
+            stacklevel=3,
+        )
+        return None
 
 
 class StrawberryDjangoPagination(StrawberryDjangoFieldBase):

--- a/strawberry_django/relay/cursor_connection.py
+++ b/strawberry_django/relay/cursor_connection.py
@@ -22,7 +22,11 @@ from strawberry.utils.await_maybe import AwaitableOrValue
 from strawberry.utils.inspect import in_async_context
 from typing_extensions import Self
 
-from strawberry_django.pagination import apply_window_pagination, get_total_count
+from strawberry_django.pagination import (
+    apply_window_pagination,
+    get_cached_total_count,
+    get_total_count,
+)
 from strawberry_django.queryset import get_queryset_config
 from strawberry_django.resolvers import django_resolver
 
@@ -342,11 +346,17 @@ class DjangoCursorConnection(relay.Connection[relay.NodeType]):
     )
 
     @strawberry.field(description="Total quantity of existing nodes.")
-    @django_resolver
     def total_count(self) -> int:
         assert self.total_count_qs is not None
 
-        return get_total_count(self.total_count_qs)
+        total_count = get_cached_total_count(self.total_count_qs)
+        if total_count is None:
+            # Getting the count requires a query; django_resolver defers it
+            # to a thread when running in an async context.
+            total_count = cast(
+                "int", django_resolver(get_total_count)(self.total_count_qs)
+            )
+        return total_count
 
     @classmethod
     def resolve_connection(

--- a/strawberry_django/relay/list_connection.py
+++ b/strawberry_django/relay/list_connection.py
@@ -14,7 +14,7 @@ from strawberry.utils.await_maybe import AwaitableOrValue
 from strawberry.utils.inspect import in_async_context
 from typing_extensions import Self, deprecated
 
-from strawberry_django.pagination import get_total_count
+from strawberry_django.pagination import get_cached_total_count, get_total_count
 from strawberry_django.queryset import get_queryset_config
 from strawberry_django.resolvers import django_resolver
 from strawberry_django.utils.typing import unwrap_type
@@ -60,7 +60,6 @@ class DjangoListConnection(relay.ListConnection[relay.NodeType]):
     nodes: strawberry.Private[NodeIterableType[relay.NodeType] | None] = None
 
     @strawberry.field(description="Total quantity of existing nodes.")
-    @django_resolver
     def total_count(self) -> int | None:
         assert self.nodes is not None
 
@@ -70,7 +69,12 @@ class DjangoListConnection(relay.ListConnection[relay.NodeType]):
             pass
 
         if isinstance(self.nodes, models.QuerySet):
-            return get_total_count(self.nodes)
+            total_count = get_cached_total_count(self.nodes)
+            if total_count is None:
+                # Getting the count requires a query; django_resolver defers
+                # it to a thread when running in an async context.
+                total_count = cast("int", django_resolver(get_total_count)(self.nodes))
+            return total_count
 
         return len(self.nodes) if isinstance(self.nodes, Sized) else None
 

--- a/tests/relay/test_prefetched_thread_hops.py
+++ b/tests/relay/test_prefetched_thread_hops.py
@@ -24,6 +24,7 @@ from strawberry import relay
 from strawberry.relay import GlobalID
 
 import strawberry_django
+from strawberry_django.fields.field import StrawberryDjangoField
 from strawberry_django.optimizer import DjangoOptimizerExtension
 from strawberry_django.relay import DjangoCursorConnection, DjangoListConnection
 from tests.projects.models import Milestone, Project
@@ -93,6 +94,38 @@ list_connection_schema_no_optimizer = strawberry.Schema(
 )
 
 
+class DbTouchingField(StrawberryDjangoField):
+    """Simulates a user field subclass whose get_queryset hits the database."""
+
+    def get_queryset(self, queryset, info, **kwargs):
+        queryset = super().get_queryset(queryset, info, **kwargs)
+        # Any ORM access here raises SynchronousOnlyOperation if the queryset
+        # hook is (incorrectly) run on the event loop instead of in a worker
+        # thread.
+        Project.objects.exists()
+        return queryset
+
+
+@strawberry_django.type(Project, name="ProjectWithDbTouchingConnection")
+class DbTouchingProjectType(relay.Node):
+    name: str
+    milestones: DjangoListConnection[MilestoneType] = strawberry_django.connection(
+        field_cls=DbTouchingField
+    )
+
+
+@strawberry.type
+class DbTouchingQuery:
+    projects_with_db_touching_connection: list[DbTouchingProjectType] = (
+        strawberry_django.field()
+    )
+
+
+db_touching_schema = strawberry.Schema(
+    query=DbTouchingQuery, extensions=[DjangoOptimizerExtension()]
+)
+
+
 CURSOR_QUERY = """
 query TestQuery {
     projects(order: { id: ASC }) {
@@ -122,6 +155,15 @@ query TestQuery {
 LIST_QUERY = """
 query TestQuery {
     projectsWithListConnection {
+        id
+        milestones { totalCount edges { node { id } } }
+    }
+}
+"""
+
+DB_TOUCHING_QUERY = """
+query TestQuery {
+    projectsWithDbTouchingConnection {
         id
         milestones { totalCount edges { node { id } } }
     }
@@ -296,3 +338,23 @@ async def test_nested_connection_without_prefetch_pays_thread_hops_per_parent(
         site.startswith(("strawberry_django.", "django.db.models.query."))
         for site in extra_call_sites
     )
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_user_get_queryset_override_keeps_its_thread_hop(thread_hops):
+    await sync_to_async(_create_projects_with_milestones)(1, 2)
+    hops_for_two_parents = await _run_and_capture_hops(
+        db_touching_schema, DB_TOUCHING_QUERY, thread_hops
+    )
+
+    await sync_to_async(_create_projects_with_milestones)(3, 3)
+    hops_for_five_parents = await _run_and_capture_hops(
+        db_touching_schema, DB_TOUCHING_QUERY, thread_hops
+    )
+
+    # A user-overridden get_queryset may hit the database (this one does), so
+    # even over prefetched data its queryset hook must not be treated as safe
+    # to run on the event loop. Resolving without errors proves it went
+    # through sync_to_async (Django raises SynchronousOnlyOperation for
+    # database access on the event loop), costing a thread hop per parent.
+    assert len(hops_for_five_parents) > len(hops_for_two_parents)

--- a/tests/relay/test_prefetched_thread_hops.py
+++ b/tests/relay/test_prefetched_thread_hops.py
@@ -9,8 +9,13 @@ of hops on list-heavy responses.
 The absolute number of hops for the root field depends on the graphql-core
 version (graphql-core 3.3+ async-iterates the root queryset, moving the fetch
 into Django's own ``sync_to_async``), so the tests assert the actual contract:
-the hop count is constant, no matter how many parent nodes are resolved.
+the hops (count and call sites) are constant, no matter how many parent nodes
+are resolved. Without the optimizer the nested data is not in memory, and the
+complementary tests assert that each parent then pays thread hops for its
+database work instead of running it on the event loop.
 """
+
+from collections import Counter
 
 import pytest
 import strawberry
@@ -20,7 +25,7 @@ from strawberry.relay import GlobalID
 
 import strawberry_django
 from strawberry_django.optimizer import DjangoOptimizerExtension
-from strawberry_django.relay import DjangoListConnection
+from strawberry_django.relay import DjangoCursorConnection, DjangoListConnection
 from tests.projects.models import Milestone, Project
 
 from .test_cursor_pagination import MilestoneType
@@ -43,6 +48,85 @@ class ListConnectionQuery:
 list_connection_schema = strawberry.Schema(
     query=ListConnectionQuery, extensions=[DjangoOptimizerExtension()]
 )
+
+
+# Building a schema mutates its connection fields (the relay extension
+# installs the default resolver on them), so the no-optimizer schemas need
+# their own copies of the types instead of reusing the ones above.
+@strawberry_django.type(Project, name="ProjectNoOptimizerCursor")
+class CursorProjectNoOptimizerType(relay.Node):
+    name: str
+    milestones: DjangoCursorConnection[MilestoneType] = strawberry_django.connection()
+
+    @classmethod
+    def get_queryset(cls, qs, info):
+        if not qs.ordered:
+            qs = qs.order_by("pk")
+        return qs
+
+
+@strawberry.type
+class CursorNoOptimizerQuery:
+    projects: DjangoCursorConnection[CursorProjectNoOptimizerType] = (
+        strawberry_django.connection()
+    )
+
+
+@strawberry_django.type(Project, name="ProjectWithListConnectionNoOptimizer")
+class ListProjectNoOptimizerType(relay.Node):
+    name: str
+    milestones: DjangoListConnection[MilestoneType] = strawberry_django.connection()
+
+
+@strawberry.type
+class ListConnectionNoOptimizerQuery:
+    projects_with_list_connection: list[ListProjectNoOptimizerType] = (
+        strawberry_django.field()
+    )
+
+
+# Without the optimizer nothing is prefetched, so nested connections must run
+# their queries in worker threads instead of on the event loop.
+cursor_schema_no_optimizer = strawberry.Schema(query=CursorNoOptimizerQuery)
+list_connection_schema_no_optimizer = strawberry.Schema(
+    query=ListConnectionNoOptimizerQuery
+)
+
+
+CURSOR_QUERY = """
+query TestQuery {
+    projects(order: { id: ASC }) {
+        edges {
+          node {
+            id
+            milestones { totalCount edges { node { id } } }
+          }
+        }
+    }
+}
+"""
+
+NO_OPTIMIZER_CURSOR_QUERY = """
+query TestQuery {
+    projects {
+        edges {
+          node {
+            id
+            milestones { totalCount edges { node { id } } }
+          }
+        }
+    }
+}
+"""
+
+LIST_QUERY = """
+query TestQuery {
+    projectsWithListConnection {
+        id
+        milestones { totalCount edges { node { id } } }
+    }
+}
+"""
 
 
 @pytest.fixture
@@ -68,12 +152,14 @@ def _create_projects_with_milestones(first_project_id: int, count: int) -> None:
         Milestone.objects.create(id=project_id * 10 + 1, project=project)
 
 
-async def _count_hops(schema, query: str, thread_hops: list[str]) -> int:
+async def _run_and_capture_hops(
+    schema, query: str, thread_hops: list[str]
+) -> list[str]:
     thread_hops.clear()
     result = await schema.execute(query)
     assert result.errors is None
     assert result.data is not None
-    return len(thread_hops)
+    return list(thread_hops)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -82,21 +168,8 @@ async def test_nested_cursor_connection_resolves_prefetched_data_without_hops(
 ):
     await sync_to_async(_create_projects_with_milestones)(1, 2)
 
-    query = """
-    query TestQuery {
-        projects(order: { id: ASC }) {
-            edges {
-              node {
-                id
-                milestones { totalCount edges { node { id } } }
-              }
-            }
-        }
-    }
-    """
-
     thread_hops.clear()
-    result = await cursor_schema.execute(query)
+    result = await cursor_schema.execute(CURSOR_QUERY)
 
     assert result.errors is None
     assert result.data == {
@@ -127,15 +200,19 @@ async def test_nested_cursor_connection_resolves_prefetched_data_without_hops(
             ],
         }
     }
-    hops_for_two_parents = len(thread_hops)
+    hops_for_two_parents = list(thread_hops)
 
     # The nested milestones (nodes, page info, totalCount) are served from the
     # prefetch cache on the event loop, so only the root connection may touch
-    # the database: adding parents must not add thread hops.
+    # the database: adding parents must not add thread hops, and the hops must
+    # keep originating from the same (root-only) call sites rather than
+    # shifting into nested per-node resolvers.
     await sync_to_async(_create_projects_with_milestones)(3, 3)
-    hops_for_five_parents = await _count_hops(cursor_schema, query, thread_hops)
+    hops_for_five_parents = await _run_and_capture_hops(
+        cursor_schema, CURSOR_QUERY, thread_hops
+    )
 
-    assert hops_for_five_parents == hops_for_two_parents, thread_hops
+    assert sorted(hops_for_five_parents) == sorted(hops_for_two_parents)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -144,17 +221,8 @@ async def test_nested_list_connection_resolves_prefetched_data_without_hops(
 ):
     await sync_to_async(_create_projects_with_milestones)(1, 2)
 
-    query = """
-    query TestQuery {
-        projectsWithListConnection {
-            id
-            milestones { totalCount edges { node { id } } }
-        }
-    }
-    """
-
     thread_hops.clear()
-    result = await list_connection_schema.execute(query)
+    result = await list_connection_schema.execute(LIST_QUERY)
 
     assert result.errors is None
     assert result.data == {
@@ -176,14 +244,55 @@ async def test_nested_list_connection_resolves_prefetched_data_without_hops(
             for project_id in (1, 2)
         ],
     }
-    hops_for_two_parents = len(thread_hops)
+    hops_for_two_parents = list(thread_hops)
 
     # The nested milestones are served from the prefetch cache on the event
     # loop, so only fetching the root list may touch the database: adding
-    # parents must not add thread hops.
+    # parents must not add thread hops, and the hops must keep originating
+    # from the same (root-only) call sites rather than shifting into nested
+    # per-node resolvers.
     await sync_to_async(_create_projects_with_milestones)(3, 3)
-    hops_for_five_parents = await _count_hops(
-        list_connection_schema, query, thread_hops
+    hops_for_five_parents = await _run_and_capture_hops(
+        list_connection_schema, LIST_QUERY, thread_hops
     )
 
-    assert hops_for_five_parents == hops_for_two_parents, thread_hops
+    assert sorted(hops_for_five_parents) == sorted(hops_for_two_parents)
+
+
+@pytest.mark.parametrize(
+    ("schema", "query"),
+    [
+        pytest.param(
+            cursor_schema_no_optimizer, NO_OPTIMIZER_CURSOR_QUERY, id="cursor"
+        ),
+        pytest.param(list_connection_schema_no_optimizer, LIST_QUERY, id="list"),
+    ],
+)
+@pytest.mark.django_db(transaction=True)
+async def test_nested_connection_without_prefetch_pays_thread_hops_per_parent(
+    schema, query, thread_hops
+):
+    await sync_to_async(_create_projects_with_milestones)(1, 2)
+    hops_for_two_parents = await _run_and_capture_hops(schema, query, thread_hops)
+
+    await sync_to_async(_create_projects_with_milestones)(3, 3)
+    hops_for_five_parents = await _run_and_capture_hops(schema, query, thread_hops)
+
+    # Without prefetch optimization the nested querysets are not in memory, so
+    # resolving each parent's nested connection (and its totalCount) must ship
+    # its database work to a worker thread instead of running it on the event
+    # loop: hops scale with the number of parents.
+    assert len(hops_for_five_parents) > len(hops_for_two_parents)
+
+    # The extra per-parent hops must be database work: this library's
+    # django_resolver wrapping (connection resolution, totalCount) and
+    # Django's own queryset-evaluation bridge — proving the work went through
+    # sync_to_async rather than being skipped as "async safe".
+    extra_call_sites = Counter(hops_for_five_parents) - Counter(hops_for_two_parents)
+    assert any(
+        site.startswith("strawberry_django.resolvers.") for site in extra_call_sites
+    )
+    assert all(
+        site.startswith(("strawberry_django.", "django.db.models.query."))
+        for site in extra_call_sites
+    )

--- a/tests/relay/test_prefetched_thread_hops.py
+++ b/tests/relay/test_prefetched_thread_hops.py
@@ -1,0 +1,189 @@
+"""Prefetch-optimized nested connections must resolve without per-node thread hops.
+
+Every ``sync_to_async`` call ships work to a worker thread (~0.1-0.2 ms each).
+For nested connections the optimizer has already prefetched all data with one
+windowed query, so resolving nodes, page info and ``totalCount`` is pure
+in-memory work — paying a thread hop per parent node multiplies into hundreds
+of hops on list-heavy responses.
+
+The absolute number of hops for the root field depends on the graphql-core
+version (graphql-core 3.3+ async-iterates the root queryset, moving the fetch
+into Django's own ``sync_to_async``), so the tests assert the actual contract:
+the hop count is constant, no matter how many parent nodes are resolved.
+"""
+
+import pytest
+import strawberry
+from asgiref.sync import SyncToAsync, sync_to_async
+from strawberry import relay
+from strawberry.relay import GlobalID
+
+import strawberry_django
+from strawberry_django.optimizer import DjangoOptimizerExtension
+from strawberry_django.relay import DjangoListConnection
+from tests.projects.models import Milestone, Project
+
+from .test_cursor_pagination import MilestoneType
+from .test_cursor_pagination import schema as cursor_schema
+
+
+@strawberry_django.type(Project, name="ProjectWithListConnection")
+class ProjectWithListConnectionType(relay.Node):
+    name: str
+    milestones: DjangoListConnection[MilestoneType] = strawberry_django.connection()
+
+
+@strawberry.type
+class ListConnectionQuery:
+    projects_with_list_connection: list[ProjectWithListConnectionType] = (
+        strawberry_django.field()
+    )
+
+
+list_connection_schema = strawberry.Schema(
+    query=ListConnectionQuery, extensions=[DjangoOptimizerExtension()]
+)
+
+
+@pytest.fixture
+def thread_hops(monkeypatch):
+    hops: list[str] = []
+    orig_call = SyncToAsync.__call__
+
+    async def counting_call(self, *args, **kwargs):
+        func = self.func
+        hops.append(
+            f"{getattr(func, '__module__', '?')}.{getattr(func, '__qualname__', '?')}"
+        )
+        return await orig_call(self, *args, **kwargs)
+
+    monkeypatch.setattr(SyncToAsync, "__call__", counting_call)
+    return hops
+
+
+def _create_projects_with_milestones(first_project_id: int, count: int) -> None:
+    for project_id in range(first_project_id, first_project_id + count):
+        project = Project.objects.create(id=project_id, name=f"Project {project_id}")
+        Milestone.objects.create(id=project_id * 10, project=project)
+        Milestone.objects.create(id=project_id * 10 + 1, project=project)
+
+
+async def _count_hops(schema, query: str, thread_hops: list[str]) -> int:
+    thread_hops.clear()
+    result = await schema.execute(query)
+    assert result.errors is None
+    assert result.data is not None
+    return len(thread_hops)
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_nested_cursor_connection_resolves_prefetched_data_without_hops(
+    thread_hops,
+):
+    await sync_to_async(_create_projects_with_milestones)(1, 2)
+
+    query = """
+    query TestQuery {
+        projects(order: { id: ASC }) {
+            edges {
+              node {
+                id
+                milestones { totalCount edges { node { id } } }
+              }
+            }
+        }
+    }
+    """
+
+    thread_hops.clear()
+    result = await cursor_schema.execute(query)
+
+    assert result.errors is None
+    assert result.data == {
+        "projects": {
+            "edges": [
+                {
+                    "node": {
+                        "id": str(GlobalID("ProjectType", str(project_id))),
+                        "milestones": {
+                            "totalCount": 2,
+                            "edges": [
+                                {
+                                    "node": {
+                                        "id": str(
+                                            GlobalID("MilestoneType", str(milestone_id))
+                                        )
+                                    }
+                                }
+                                for milestone_id in (
+                                    project_id * 10,
+                                    project_id * 10 + 1,
+                                )
+                            ],
+                        },
+                    }
+                }
+                for project_id in (1, 2)
+            ],
+        }
+    }
+    hops_for_two_parents = len(thread_hops)
+
+    # The nested milestones (nodes, page info, totalCount) are served from the
+    # prefetch cache on the event loop, so only the root connection may touch
+    # the database: adding parents must not add thread hops.
+    await sync_to_async(_create_projects_with_milestones)(3, 3)
+    hops_for_five_parents = await _count_hops(cursor_schema, query, thread_hops)
+
+    assert hops_for_five_parents == hops_for_two_parents, thread_hops
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_nested_list_connection_resolves_prefetched_data_without_hops(
+    thread_hops,
+):
+    await sync_to_async(_create_projects_with_milestones)(1, 2)
+
+    query = """
+    query TestQuery {
+        projectsWithListConnection {
+            id
+            milestones { totalCount edges { node { id } } }
+        }
+    }
+    """
+
+    thread_hops.clear()
+    result = await list_connection_schema.execute(query)
+
+    assert result.errors is None
+    assert result.data == {
+        "projectsWithListConnection": [
+            {
+                "id": str(GlobalID("ProjectWithListConnection", str(project_id))),
+                "milestones": {
+                    "totalCount": 2,
+                    "edges": [
+                        {
+                            "node": {
+                                "id": str(GlobalID("MilestoneType", str(milestone_id)))
+                            }
+                        }
+                        for milestone_id in (project_id * 10, project_id * 10 + 1)
+                    ],
+                },
+            }
+            for project_id in (1, 2)
+        ],
+    }
+    hops_for_two_parents = len(thread_hops)
+
+    # The nested milestones are served from the prefetch cache on the event
+    # loop, so only fetching the root list may touch the database: adding
+    # parents must not add thread hops.
+    await sync_to_async(_create_projects_with_milestones)(3, 3)
+    hops_for_five_parents = await _count_hops(
+        list_connection_schema, query, thread_hops
+    )
+
+    assert hops_for_five_parents == hops_for_two_parents, thread_hops

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -13,7 +13,10 @@ from strawberry_django.pagination import (
     OffsetPaginationInput,
     apply,
     apply_window_pagination,
+    get_cached_total_count,
+    get_total_count,
 )
+from strawberry_django.queryset import get_queryset_config
 from tests import models, utils
 from tests.projects.faker import (
     IssueFactory,
@@ -152,6 +155,115 @@ def test_apply_window_pagination_with_no_limites(limit):
     assert first_fruit.name == "fruit2"
     assert first_fruit._strawberry_row_number == 3  # type: ignore
     assert first_fruit._strawberry_total_count == 10  # type: ignore
+
+
+def _prefetch_optimized_fruits_queryset():
+    """Build a queryset in the state the optimizer leaves prefetched relations in.
+
+    The optimizer applies window pagination to the prefetch queryset and marks
+    it as optimized-by-prefetching; Django then evaluates it, populating
+    `_result_cache` with rows carrying the window annotations.
+    """
+    queryset = apply_window_pagination(
+        models.Fruit.objects.all(),
+        related_field_id="color_id",
+        offset=0,
+        limit=10,
+    )
+    get_queryset_config(queryset).optimized_by_prefetching = True
+    return queryset
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_cached_total_count_returns_none_for_non_optimized_queryset():
+    color = models.Color.objects.create(name="Red")
+    models.Fruit.objects.create(name="fruit", color=color)
+
+    queryset = models.Fruit.objects.all()
+    list(queryset)  # populate _result_cache
+
+    with utils.assert_num_queries(0):
+        assert get_cached_total_count(queryset) is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_cached_total_count_returns_none_for_unevaluated_queryset():
+    color = models.Color.objects.create(name="Red")
+    models.Fruit.objects.create(name="fruit", color=color)
+
+    queryset = _prefetch_optimized_fruits_queryset()
+    assert queryset._result_cache is None  # type: ignore
+
+    with utils.assert_num_queries(0):
+        assert get_cached_total_count(queryset) is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_cached_total_count_returns_none_for_empty_result_cache():
+    queryset = _prefetch_optimized_fruits_queryset()
+    assert list(queryset) == []
+
+    with utils.assert_num_queries(0):
+        assert get_cached_total_count(queryset) is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_cached_total_count_reads_window_annotation_without_queries():
+    color = models.Color.objects.create(name="Red")
+    for i in range(3):
+        models.Fruit.objects.create(name=f"fruit{i}", color=color)
+
+    queryset = _prefetch_optimized_fruits_queryset()
+    list(queryset)  # populate _result_cache with annotated rows
+
+    with utils.assert_num_queries(0):
+        assert get_cached_total_count(queryset) == 3
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_cached_total_count_returns_none_for_distinct_queryset():
+    color = models.Color.objects.create(name="Red")
+    for i in range(3):
+        models.Fruit.objects.create(name=f"fruit{i}", color=color)
+
+    queryset = _prefetch_optimized_fruits_queryset().distinct()
+    list(queryset)  # populate _result_cache with annotated rows
+
+    # Window functions are evaluated before DISTINCT in SQL, so the annotation
+    # can't be trusted and the cached count must not be used.
+    with utils.assert_num_queries(0):
+        assert get_cached_total_count(queryset) is None
+
+    # get_total_count must fall back to a real COUNT query instead.
+    with utils.assert_num_queries(1):
+        assert get_total_count(queryset) == 3
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_cached_total_count_warns_when_annotations_are_missing():
+    color = models.Color.objects.create(name="Red")
+    for i in range(2):
+        models.Fruit.objects.create(name=f"fruit{i}", color=color)
+
+    # Optimized-by-prefetching queryset whose cached rows lack the window
+    # annotations (e.g. window pagination was never applied to it).
+    queryset = models.Fruit.objects.all()
+    get_queryset_config(queryset).optimized_by_prefetching = True
+    list(queryset)  # populate _result_cache with non-annotated rows
+
+    warning_match = "Pagination annotations not found"
+    with (
+        pytest.warns(RuntimeWarning, match=warning_match),
+        utils.assert_num_queries(0),
+    ):
+        assert get_cached_total_count(queryset) is None
+
+    # get_total_count must fall back to a real COUNT query instead.
+    with (
+        pytest.warns(RuntimeWarning, match=warning_match),
+        utils.assert_num_queries(1),
+    ):
+        assert get_total_count(queryset) == 2
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Every sync resolver runs through sync_to_async in async contexts, costing a thread hop (~0.1-0.2 ms) per call. For nested connections the optimizer has already fetched everything with one windowed prefetch query, yet each parent node still paid three hops for pure in-memory work: the connection default resolver (builds the related queryset without evaluating it), the queryset hook (short-circuits for prefetch-optimized querysets) and totalCount (reads the _strawberry_total_count window annotation off a cached row).

- The connection default resolver is marked `is_async_safe` and skipped by the django_resolver wrapping in `safe_resolver`; its only potentially database-touching path (resolve_model_nodes, which may run user-defined get_queryset) is explicitly deferred to a thread in async contexts.
- `get_result` applies the queryset hook inline when the queryset is prefetch-optimized and its results are already cached.
- `total_count` reads the cached window annotation inline via the new `get_cached_total_count` helper and defers to a thread only when a real COUNT query is unavoidable.

Nested cursor connection resolution over prefetched data drops from 9 to 3 thread hops (only the root connection touches the database); nested list connections drop from 7 to 1.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Optimize resolution of prefetch-optimized nested connections to avoid unnecessary sync_to_async thread hops while preserving correct pagination counts.

Enhancements:
- Use cached window annotations via a new helper to serve totalCount for prefetch-optimized querysets without hitting the database.
- Treat library-internal connection default resolvers and queryset hooks as async-safe when operating purely on prefetched data, skipping sync_to_async wrapping in async contexts.
- Refine safe_resolver behavior to respect async-safe resolvers so nested connection resolution over prefetched data runs on the event loop.

Documentation:
- Add a release note describing the optimization of nested connections to resolve prefetched data without per-node thread hops.

Tests:
- Add coverage for get_cached_total_count and its interaction with distinct querysets and missing pagination annotations.
- Add async tests that track SyncToAsync call sites to enforce constant thread hops for prefetched nested connections and per-parent hops when data is not prefetched.

Chores:
- Introduce RELEASE.md with patch-level release metadata for this optimization.