### PR TITLE
Use Strawberry exception handlers for Django errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+---
+release type: minor
+---
+
+Add `DjangoExceptionHandler`, a schema-level Strawberry exception handler for
+converting Django `ValidationError`, `PermissionDenied`, and `ObjectDoesNotExist`
+exceptions into `OperationInfo` results. Combined with `handle_django_errors=True`,
+it also handles exceptions raised during input conversion or by sync and async field
+extensions.

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -187,6 +187,34 @@ def some_mutation(self, data: str) -> Result:
     pass
 ```
 
+## Handling Errors Outside the Resolver
+
+`handle_django_errors=True` handles exceptions raised by the mutation resolver and
+adds `OperationInfo` to its return union. To handle the same Django exceptions from
+the rest of Strawberry's field execution pipeline, register
+`DjangoExceptionHandler` on the schema:
+
+```python title="schema.py"
+import strawberry
+import strawberry_django
+
+from .mutations import Mutation
+from .queries import Query
+
+
+schema = strawberry.Schema(
+    query=Query,
+    mutation=Mutation,
+    exception_handlers=[strawberry_django.DjangoExceptionHandler()],
+)
+```
+
+The schema-level handler also converts supported exceptions raised while building
+input objects or running field extensions, including async extensions. It is only
+selected for fields whose return union contains `OperationInfo`, so unrelated fields
+continue to return normal GraphQL errors. Using `handle_django_errors=True` adds that
+union member automatically.
+
 ## Custom Error Handling
 
 ### Custom Exception Classes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Framework :: Django :: 6.0",
 ]
 requires-python = ">=3.10,<4.0"
-dependencies = ["django>=5.2", "asgiref>=3.8", "strawberry-graphql>=0.310.1"]
+dependencies = ["django>=5.2", "asgiref>=3.8", "strawberry-graphql>=0.321.0"]
 
 [project.urls]
 homepage = "https://strawberry.rocks/docs/django"

--- a/strawberry_django/__init__.py
+++ b/strawberry_django/__init__.py
@@ -2,6 +2,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 from . import auth, federation, filters, mutations, ordering, pagination, relay
+from .exception_handlers import DjangoExceptionHandler
 from .fields.field import connection, field, node, offset_paginated
 from .fields.filter_order import filter_field, order_field
 from .fields.filter_types import (
@@ -40,6 +41,7 @@ __all__ = [
     "ComparisonFilterLookup",
     "DateFilterLookup",
     "DatetimeFilterLookup",
+    "DjangoExceptionHandler",
     "DjangoFileType",
     "DjangoImageType",
     "DjangoModelType",

--- a/strawberry_django/exception_handlers.py
+++ b/strawberry_django/exception_handlers.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+
+import strawberry
+from django.core.exceptions import (
+    NON_FIELD_ERRORS,
+    ObjectDoesNotExist,
+    PermissionDenied,
+    ValidationError,
+)
+from strawberry.utils.str_converters import to_camel_case
+
+from strawberry_django.fields.types import OperationInfo, OperationMessage
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from strawberry.types import Info
+    from strawberry.types.field import StrawberryField
+
+DjangoError: TypeAlias = ValidationError | PermissionDenied | ObjectDoesNotExist
+
+
+def _get_validation_error_message(error: ValidationError) -> str:
+    if not error.message:
+        return "Unknown error"
+
+    return error.message % error.params if error.params else error.message
+
+
+def _get_validation_errors(error: DjangoError) -> Iterator[OperationMessage]:
+    if isinstance(error, PermissionDenied):
+        kind = OperationMessage.Kind.PERMISSION
+    elif isinstance(error, ValidationError):
+        kind = OperationMessage.Kind.VALIDATION
+    else:
+        kind = OperationMessage.Kind.ERROR
+
+    if isinstance(error, ValidationError) and hasattr(error, "error_dict"):
+        for field, field_errors in (error.error_dict or {}).items():
+            for field_error in field_errors:
+                yield OperationMessage(
+                    kind=kind,
+                    field=(to_camel_case(field) if field != NON_FIELD_ERRORS else None),
+                    message=_get_validation_error_message(field_error),
+                    code=getattr(field_error, "code", None),
+                )
+    elif isinstance(error, ValidationError) and hasattr(error, "error_list"):
+        for list_error in error.error_list or []:
+            yield OperationMessage(
+                kind=kind,
+                message=_get_validation_error_message(list_error),
+                code=getattr(error, "code", None),
+            )
+    else:
+        message = getattr(error, "msg", None)
+        if message is None:
+            message = str(error)
+
+        yield OperationMessage(
+            kind=kind,
+            message=message,
+            code=getattr(error, "code", None),
+        )
+
+
+def _operation_info_from_exception(error: DjangoError) -> OperationInfo:
+    return OperationInfo(messages=list(_get_validation_errors(error)))
+
+
+class DjangoExceptionHandler(
+    strawberry.ExceptionHandler[DjangoError, OperationInfo],
+):
+    """Convert expected Django exceptions into ``OperationInfo`` results."""
+
+    def handle(
+        self,
+        exception: DjangoError,
+        *,
+        field: StrawberryField,
+        info: Info,
+    ) -> OperationInfo:
+        return _operation_info_from_exception(exception)

--- a/strawberry_django/mutations/fields.py
+++ b/strawberry_django/mutations/fields.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Annotated, Any, TypeVar, Union
 
 import strawberry
 from django.core.exceptions import (
-    NON_FIELD_ERRORS,
     ObjectDoesNotExist,
     PermissionDenied,
     ValidationError,
@@ -17,11 +16,12 @@ from strawberry.types.field import UNRESOLVED
 from strawberry.utils.str_converters import capitalize_first, to_camel_case
 
 from strawberry_django.arguments import argument
+from strawberry_django.exception_handlers import _operation_info_from_exception
 from strawberry_django.fields.field import (
     StrawberryDjangoFieldBase,
     StrawberryDjangoFieldFilters,
 )
-from strawberry_django.fields.types import OperationInfo, OperationMessage
+from strawberry_django.fields.types import OperationInfo
 from strawberry_django.optimizer import DjangoOptimizerExtension, optimize
 from strawberry_django.permissions import filter_with_perms, get_with_perms
 from strawberry_django.resolvers import django_resolver
@@ -47,62 +47,6 @@ if TYPE_CHECKING:
     from .types import FullCleanOptions
 
 _T = TypeVar("_T", bound="models.Model | list[models.Model]")
-
-
-def _get_validaton_error_message(error: ValidationError):
-    if not error.message:
-        return "Unknown error"
-
-    return error.message % error.params if error.params else error.message
-
-
-def _get_validation_errors(error: Exception):
-    if isinstance(error, PermissionDenied):
-        kind = OperationMessage.Kind.PERMISSION
-    elif isinstance(error, ValidationError):
-        kind = OperationMessage.Kind.VALIDATION
-    elif isinstance(error, ObjectDoesNotExist):
-        kind = OperationMessage.Kind.ERROR
-    else:
-        kind = OperationMessage.Kind.ERROR
-
-    if isinstance(error, ValidationError) and hasattr(error, "error_dict"):
-        # convert field errors
-        for field, field_errors in (error.error_dict or {}).items():
-            for e in field_errors:
-                yield OperationMessage(
-                    kind=kind,
-                    field=to_camel_case(field) if field != NON_FIELD_ERRORS else None,
-                    message=_get_validaton_error_message(e),
-                    code=getattr(e, "code", None),
-                )
-    elif isinstance(error, ValidationError) and hasattr(error, "error_list"):
-        # convert non-field errors
-        for e in error.error_list or []:
-            yield OperationMessage(
-                kind=kind,
-                message=_get_validaton_error_message(e),
-                code=getattr(error, "code", None),
-            )
-    else:
-        msg = getattr(error, "msg", None)
-        if msg is None:
-            msg = str(error)
-
-        yield OperationMessage(
-            kind=kind,
-            message=msg,
-            code=getattr(error, "code", None),
-        )
-
-
-def _handle_exception(error: Exception):
-    if isinstance(error, (ValidationError, PermissionDenied, ObjectDoesNotExist)):
-        return OperationInfo(
-            messages=list(_get_validation_errors(error)),
-        )
-
-    raise error
 
 
 class DjangoMutationBase(StrawberryDjangoFieldBase):
@@ -166,19 +110,18 @@ class DjangoMutationBase(StrawberryDjangoFieldBase):
         if not self.handle_errors:
             return self.resolver(source, info, args, kwargs)
 
-        # TODO: Any other exception types that we should capture here?
         try:
             resolved = self.resolver(source, info, args, kwargs)
-        except Exception as e:  # noqa: BLE001
-            return _handle_exception(e)
+        except (ValidationError, PermissionDenied, ObjectDoesNotExist) as error:
+            return _operation_info_from_exception(error)
 
         if inspect.isawaitable(resolved):
 
             async def async_resolver():
                 try:
                     return await resolved
-                except Exception as e:  # noqa: BLE001
-                    return _handle_exception(e)
+                except (ValidationError, PermissionDenied, ObjectDoesNotExist) as error:
+                    return _operation_info_from_exception(error)
 
             return async_resolver()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def schema(request):
         tags: list[types.Tag] = strawberry_django.field()
 
     if request.param == "optimizer_enabled":
-        extensions = [DjangoOptimizerExtension()]
+        extensions = [DjangoOptimizerExtension]
     elif request.param == "optimizer_disabled":
         extensions = []
     else:

--- a/tests/extensions/test_validation_cache.py
+++ b/tests/extensions/test_validation_cache.py
@@ -20,7 +20,7 @@ def test_validation_cache_extension(mock_validate):
         def ping(self) -> str:
             return "pong"
 
-    schema = strawberry.Schema(query=Query, extensions=[DjangoValidationCache()])
+    schema = strawberry.Schema(query=Query, extensions=[DjangoValidationCache])
 
     query = "query { hello }"
 

--- a/tests/federation/test_resolve_reference.py
+++ b/tests/federation/test_resolve_reference.py
@@ -191,7 +191,7 @@ def test_resolve_reference_uses_optimizer_extension():
     schema = FederationSchema(
         query=Query,
         types=[FruitType],
-        extensions=[RecordingOptimizerExtension()],
+        extensions=[RecordingOptimizerExtension],
     )
 
     fruit = models.Fruit.objects.create(name="optimized-fruit")

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -682,7 +682,7 @@ def test_entities_resolver_with_optimizer():
     schema = FederationSchema(
         query=Query,
         types=[FruitType],
-        extensions=[DjangoOptimizerExtension()],
+        extensions=[DjangoOptimizerExtension],
     )
 
     fruit = models.Fruit.objects.create(name="optimized")
@@ -732,7 +732,7 @@ def test_entities_resolver_with_optimizer_and_fk():
     schema = FederationSchema(
         query=Query,
         types=[FruitType, ColorType],
-        extensions=[DjangoOptimizerExtension()],
+        extensions=[DjangoOptimizerExtension],
     )
 
     color = models.Color.objects.create(name="yellow")

--- a/tests/relay/test_cursor_pagination.py
+++ b/tests/relay/test_cursor_pagination.py
@@ -92,7 +92,7 @@ class Query:
         return cast("list[ProjectType]", Project.objects.all().order_by("-pk"))
 
 
-schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension()])
+schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
 
 
 @pytest.fixture
@@ -1447,7 +1447,7 @@ def test_connection_distinct_with_m2m_filters():
         fruits: DjangoCursorConnection[FruitGQL] = strawberry_django.connection()
 
     fruit_schema = strawberry.Schema(
-        query=FruitQuery, extensions=[DjangoOptimizerExtension()]
+        query=FruitQuery, extensions=[DjangoOptimizerExtension]
     )
 
     ft1 = models.FruitType.objects.create(name="tropical")
@@ -1520,7 +1520,7 @@ def test_connection_distinct_with_pagination():
         fruits: DjangoCursorConnection[FruitGQL] = strawberry_django.connection()
 
     fruit_schema = strawberry.Schema(
-        query=FruitQuery, extensions=[DjangoOptimizerExtension()]
+        query=FruitQuery, extensions=[DjangoOptimizerExtension]
     )
 
     ft1 = models.FruitType.objects.create(name="tropical")

--- a/tests/test_custom_connection.py
+++ b/tests/test_custom_connection.py
@@ -147,7 +147,9 @@ def test_fragment_with_standard_connection_no_n1(enable_only_optimization: bool)
     standard_schema = strawberry.Schema(
         query=StandardQuery,
         extensions=[
-            DjangoOptimizerExtension(enable_only_optimization=enable_only_optimization)
+            lambda: DjangoOptimizerExtension(
+                enable_only_optimization=enable_only_optimization,
+            ),
         ],
     )
 
@@ -243,7 +245,9 @@ def test_fragment_with_custom_connection_no_n1(enable_only_optimization: bool):
     schema = strawberry.Schema(
         query=Query,
         extensions=[
-            DjangoOptimizerExtension(enable_only_optimization=enable_only_optimization)
+            lambda: DjangoOptimizerExtension(
+                enable_only_optimization=enable_only_optimization,
+            ),
         ],
     )
 

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+import strawberry
+from django.core.exceptions import (
+    ObjectDoesNotExist,
+    PermissionDenied,
+    ValidationError,
+)
+from strawberry.extensions.field_extension import FieldExtension
+
+import strawberry_django
+from strawberry_django.fields.types import OperationInfo  # noqa: TC001
+
+
+@strawberry.type
+class Query:
+    ok: bool = True
+
+
+@strawberry.type
+class Success:
+    value: str
+
+
+@strawberry.input
+class InvalidCreateInput:
+    value: str
+
+    def __post_init__(self) -> None:
+        raise ValidationError({"value": "invalid input"})
+
+
+OPERATION = """
+    mutation {
+        create(value: "test") {
+            ... on Success {
+                value
+            }
+            ... on OperationInfo {
+                messages {
+                    kind
+                    message
+                    field
+                    code
+                }
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_message"),
+    [
+        (
+            ValidationError(
+                {"snake_case_field": [ValidationError("invalid", code="invalid")]},
+            ),
+            {
+                "kind": "VALIDATION",
+                "message": "invalid",
+                "field": "snakeCaseField",
+                "code": "invalid",
+            },
+        ),
+        (
+            PermissionDenied("denied"),
+            {
+                "kind": "PERMISSION",
+                "message": "denied",
+                "field": None,
+                "code": None,
+            },
+        ),
+        (
+            ObjectDoesNotExist("missing"),
+            {
+                "kind": "ERROR",
+                "message": "missing",
+                "field": None,
+                "code": None,
+            },
+        ),
+    ],
+)
+def test_django_exception_handler_converts_supported_exceptions(
+    exception: Exception,
+    expected_message: dict[str, Any],
+) -> None:
+    @strawberry.type
+    class Mutation:
+        @strawberry_django.mutation(handle_django_errors=False)
+        def create(self, value: str) -> Success | OperationInfo:
+            raise exception
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[strawberry_django.DjangoExceptionHandler()],
+    )
+
+    result = schema.execute_sync(OPERATION)
+
+    assert result.errors is None
+    assert result.data == {"create": {"messages": [expected_message]}}
+
+
+def test_django_exception_handler_converts_argument_conversion_error() -> None:
+    @strawberry.type
+    class Mutation:
+        @strawberry_django.mutation(handle_django_errors=True)
+        def create(self, data: InvalidCreateInput) -> Success:
+            return Success(value=data.value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[strawberry_django.DjangoExceptionHandler()],
+    )
+
+    result = schema.execute_sync(
+        """
+        mutation {
+            create(data: { value: "test" }) {
+                ... on Success {
+                    value
+                }
+                ... on OperationInfo {
+                    messages {
+                        kind
+                        message
+                        field
+                    }
+                }
+            }
+        }
+        """,
+    )
+
+    assert result.errors is None
+    assert result.data == {
+        "create": {
+            "messages": [
+                {
+                    "kind": "VALIDATION",
+                    "message": "invalid input",
+                    "field": "value",
+                },
+            ],
+        },
+    }
+
+
+def test_django_exception_handler_converts_field_extension_error() -> None:
+    class FailingExtension(FieldExtension):
+        def resolve(self, next_, source, info, **kwargs):
+            raise ValidationError("sync extension failed")
+
+    @strawberry.type
+    class Mutation:
+        @strawberry_django.mutation(
+            handle_django_errors=True,
+            extensions=[FailingExtension()],
+        )
+        def create(self, value: str) -> Success:
+            return Success(value=value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[strawberry_django.DjangoExceptionHandler()],
+    )
+
+    result = schema.execute_sync(OPERATION)
+
+    assert result.errors is None
+    assert result.data == {
+        "create": {
+            "messages": [
+                {
+                    "kind": "VALIDATION",
+                    "message": "sync extension failed",
+                    "field": None,
+                    "code": None,
+                },
+            ],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_django_exception_handler_converts_async_field_extension_error() -> None:
+    class FailingExtension(FieldExtension):
+        async def resolve_async(
+            self,
+            next_,
+            source,
+            info,
+            **kwargs,
+        ):
+            raise ValidationError("async extension failed")
+
+    @strawberry.type
+    class Mutation:
+        @strawberry_django.mutation(
+            handle_django_errors=True,
+            extensions=[FailingExtension()],
+        )
+        async def create(self, value: str) -> Success:
+            return Success(value=value)
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[strawberry_django.DjangoExceptionHandler()],
+    )
+
+    result = await schema.execute(OPERATION)
+
+    assert result.errors is None
+    assert result.data == {
+        "create": {
+            "messages": [
+                {
+                    "kind": "VALIDATION",
+                    "message": "async extension failed",
+                    "field": None,
+                    "code": None,
+                },
+            ],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_django_exception_handler_is_safe_across_concurrent_executions() -> None:
+    @strawberry.type
+    class Mutation:
+        @strawberry_django.mutation(handle_django_errors=False)
+        async def create(self, value: int) -> Success | OperationInfo:
+            await asyncio.sleep(0)
+            raise ValidationError({"value": f"invalid {value}"})
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[strawberry_django.DjangoExceptionHandler()],
+    )
+    operation = """
+        mutation Create($value: Int!) {
+            create(value: $value) {
+                ... on OperationInfo {
+                    messages {
+                        message
+                    }
+                }
+            }
+        }
+    """
+
+    results = await asyncio.gather(
+        *(
+            schema.execute(operation, variable_values={"value": value})
+            for value in range(100)
+        ),
+    )
+
+    for value, result in enumerate(results):
+        assert result.errors is None
+        assert result.data == {
+            "create": {"messages": [{"message": f"invalid {value}"}]},
+        }
+
+
+def test_django_exception_handler_only_applies_to_operation_info_unions() -> None:
+    @strawberry.type
+    class Mutation:
+        @strawberry.mutation
+        def create(self, value: str) -> Success:
+            raise ValidationError("invalid")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        exception_handlers=[strawberry_django.DjangoExceptionHandler()],
+    )
+
+    result = schema.execute_sync(
+        'mutation { create(value: "test") { value } }',
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert result.errors[0].message == "invalid"

--- a/tests/test_field_permissions.py
+++ b/tests/test_field_permissions.py
@@ -109,7 +109,7 @@ async def test_with_async_permission_and_optimizer(db):
 
     schema = strawberry.Schema(
         query=Query,
-        extensions=[DjangoOptimizerExtension()],
+        extensions=[DjangoOptimizerExtension],
     )
     query = """
         query {
@@ -240,7 +240,7 @@ def test_with_sync_permission_and_optimizer(db):
 
     schema = strawberry.Schema(
         query=Query,
-        extensions=[DjangoOptimizerExtension()],
+        extensions=[DjangoOptimizerExtension],
     )
     query = """
         query {

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -1364,7 +1364,7 @@ def test_offset_paginated_runs_perms_optimizer_and_type_hook_once(mocker):
     perms_spy = mocker.spy(field_mod, "filter_with_perms")
     optimize_spy = mocker.spy(DjangoOptimizerExtension, "optimize")
 
-    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension()])
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
     models.Fruit.objects.create(name="Apple")
 
     res = schema.execute_sync(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,7 +37,7 @@ def generate_query(query=None, mutation=None, enable_optimizer=False):
     extensions = []
 
     if enable_optimizer:
-        extensions = [DjangoOptimizerExtension()]
+        extensions = [DjangoOptimizerExtension]
     schema = strawberry.Schema(query=query, mutation=mutation, extensions=extensions)
 
     def process_result(result):

--- a/uv.lock
+++ b/uv.lock
@@ -156,14 +156,14 @@ toml = [
 
 [[package]]
 name = "cross-web"
-version = "0.4.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/4f/bdb62e969649ee76d4741ef8eee34384ec2bc21cc66eb7fd244e6ad62be8/cross_web-0.4.0.tar.gz", hash = "sha256:4ae65619ddfcd06d6803432c0366342d7e8aeba10194b4e144d73a662e75370c", size = 157111, upload-time = "2025-12-25T20:45:21.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/a0/bdb8370215987cc5bde497cb8b976b17ab14841566ecef2aab6ae3e6c7b0/cross_web-0.7.0.tar.gz", hash = "sha256:15fbc8b9a824a055db8127fd6e43e0773074f620fdecb6b2b587d3d0a2bdd459", size = 332407, upload-time = "2026-05-19T14:18:48.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/d6/6c6a036655e5091b26b9f350dcf43821895325aa4727396b14c67679a957/cross_web-0.4.0-py3-none-any.whl", hash = "sha256:0c675bd26e91428cab31e3e927929b42da94aa96da92974e57c78f9a732d0e9b", size = 14200, upload-time = "2025-12-25T20:45:23.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4a/78b52ec2edcbd9b123638f4e0421fd8699ebe653ebf63ac5f82abd2665bc/cross_web-0.7.0-py3-none-any.whl", hash = "sha256:ddea9be3c68b48eaf16561847a5831a559786949c544b3701432e00a4e8d19d9", size = 25207, upload-time = "2026-05-19T14:18:47.614Z" },
 ]
 
 [[package]]
@@ -732,7 +732,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.310.1"
+version = "0.321.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cross-web" },
@@ -741,9 +741,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/65/8fc31347cd1a2809ea72ec4c354fc6996c79f64f0cd84df9707117045d2e/strawberry_graphql-0.310.1.tar.gz", hash = "sha256:bd01edc3016d8caea543dc8a1d2394d5257a87a36e9fbe8c3aedeeda7c2c8ec1", size = 211966, upload-time = "2026-03-08T14:00:46.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/b0/e2e13fadbf291fd7ee1c89a7f3d6872424ad299018a3adfd6ac8459ba21c/strawberry_graphql-0.321.0.tar.gz", hash = "sha256:54e916c83f21219bbe3067b40ca4d10d550a487ea6690336e3be9e5536409214", size = 233479, upload-time = "2026-07-13T20:56:02.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/f7/90f885565fb3fbc44c54bda17dd4c36a5c6d9b84ecfa7a6d49d30084cab3/strawberry_graphql-0.310.1-py3-none-any.whl", hash = "sha256:d6da1f16cab2b9cb4a9d5e0c196a33f98f76157d559e5afbb48e81348db163d0", size = 309316, upload-time = "2026-03-08T14:00:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/9d4d280ccb675fb4273a9e7f1d67b67fbd4ce7baaa15dba646bc20759915/strawberry_graphql-0.321.0-py3-none-any.whl", hash = "sha256:bd85d8a3eda351cc4a952d3d6216096b112c94ee9149e18c4cda754bb967c0d9", size = 336994, upload-time = "2026-07-13T20:56:01.075Z" },
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ requires-dist = [
     { name = "django-choices-field", marker = "extra == 'enum'", specifier = ">=2.2.2" },
     { name = "django-debug-toolbar", marker = "extra == 'debug-toolbar'", specifier = ">=6.0.0" },
     { name = "django-polymorphic", marker = "extra == 'polymorphic'", specifier = ">=4.0.0" },
-    { name = "strawberry-graphql", specifier = ">=0.310.1" },
+    { name = "strawberry-graphql", specifier = ">=0.321.0" },
 ]
 provides-extras = ["debug-toolbar", "enum", "polymorphic"]
 


### PR DESCRIPTION
<!-- shortcake:start -->
## Stack [🍰](https://shortcake.patrick.wtf)

- **#935** (`2026-07-13-use-strawberry-exception-handlers-for-django-error`) <-- this PR
<!-- shortcake:end -->

## Summary by Sourcery

Introduce a reusable Django exception handler that converts common Django errors into OperationInfo and integrate it into mutation error handling, while updating schema extension usage and dependencies.

New Features:
- Add a DjangoExceptionHandler schema-level handler to convert ValidationError, PermissionDenied, and ObjectDoesNotExist into OperationInfo results.
- Expose DjangoExceptionHandler from the main strawberry_django package for convenient import.

Enhancements:
- Refactor Django mutation error handling to reuse the shared OperationInfo conversion logic and narrow caught exceptions.
- Update tests and schema definitions to use extension classes/factories instead of instantiated extensions where required.
- Document how to enable DjangoExceptionHandler for handling errors outside mutation resolvers.
- Declare compatibility with a newer strawberry-graphql version and update the dependency constraint.

Documentation:
- Add guidance on configuring DjangoExceptionHandler to handle Django errors raised outside mutation resolvers, including during input construction and field extensions.

Tests:
- Add comprehensive tests covering DjangoExceptionHandler behavior, including argument conversion errors, sync and async field extensions, concurrency safety, and fallback to normal GraphQL errors when OperationInfo is not in the return union.

Chores:
- Add a release note describing the new DjangoExceptionHandler feature and its integration with handle_django_errors.