### PR TITLE
fix: support interfaces in mutation error unions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+---
+release type: patch
+---
+
+Allow mutations with Django error handling to return interfaces by expanding them to their concrete implementations.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 ---
-release type: patch
+release type: minor
 ---
 
 Allow mutations with Django error handling to return interfaces by expanding them to their concrete implementations.

--- a/strawberry_django/mutations/fields.py
+++ b/strawberry_django/mutations/fields.py
@@ -13,6 +13,7 @@ from django.core.exceptions import (
 from django.db import models, transaction
 from strawberry import UNSET, relay
 from strawberry.annotation import StrawberryAnnotation
+from strawberry.types import get_object_definition
 from strawberry.types.field import UNRESOLVED
 from strawberry.utils.str_converters import capitalize_first, to_camel_case
 
@@ -47,6 +48,34 @@ if TYPE_CHECKING:
     from .types import FullCleanOptions
 
 _T = TypeVar("_T", bound="models.Model | list[models.Model]")
+
+
+def _get_interface_implementations(interface: type) -> Iterable[type]:
+    for subclass in interface.__subclasses__():
+        definition = get_object_definition(subclass)
+        if (
+            definition is not None
+            and definition.origin is subclass
+            and definition.is_object_type
+        ):
+            yield subclass
+
+        yield from _get_interface_implementations(subclass)
+
+
+def _get_mutation_types(gql_type: StrawberryType | type) -> Iterable[type]:
+    seen = set()
+    for possible_type in get_possible_types(gql_type):
+        definition = get_object_definition(possible_type)
+        types = (
+            _get_interface_implementations(possible_type)
+            if definition is not None and definition.is_interface
+            else (possible_type,)
+        )
+        for concrete_type in types:
+            if concrete_type not in seen:
+                seen.add(concrete_type)
+                yield concrete_type
 
 
 def _get_validaton_error_message(error: ValidationError):
@@ -138,7 +167,7 @@ class DjangoMutationBase(StrawberryDjangoFieldBase):
             return resolved
 
         if self.handle_errors and not self._resolved_return_type:
-            types_ = tuple(get_possible_types(resolved))
+            types_ = tuple(_get_mutation_types(resolved))
             if OperationInfo not in types_:
                 types_ = (*types_, OperationInfo)
 

--- a/tests/mutations/test_interface.py
+++ b/tests/mutations/test_interface.py
@@ -1,0 +1,55 @@
+import strawberry
+
+from strawberry_django import mutations
+
+
+def test_mutation_returning_interface_with_error_handling():
+    @strawberry.interface
+    class Project:
+        name: str
+
+    @strawberry.type
+    class WebProject(Project):
+        url: str
+
+    @strawberry.type
+    class ExternalProject(Project):
+        provider: str
+
+    @strawberry.type
+    class Query:
+        value: str = "value"
+
+    @strawberry.type
+    class Mutation:
+        @mutations.mutation(handle_django_errors=True)
+        def update_project(self) -> Project:
+            return WebProject(name="site", url="https://example.com")
+
+    schema = strawberry.Schema(
+        query=Query,
+        mutation=Mutation,
+        types=[WebProject, ExternalProject],
+    )
+    result = schema.execute_sync(
+        """
+        mutation {
+          updateProject {
+            __typename
+            ... on WebProject {
+              name
+              url
+            }
+          }
+        }
+        """
+    )
+
+    assert result.errors is None
+    assert result.data == {
+        "updateProject": {
+            "__typename": "WebProject",
+            "name": "site",
+            "url": "https://example.com",
+        }
+    }


### PR DESCRIPTION
Expands interface return types to their concrete object implementations before building the mutation payload union. This keeps Django error handling compatible with interface-based mutations.

Tests: focused mutation tests, Ruff, and Pyright.

Closes #797.

## Summary by Sourcery

Support interface return types in mutation error unions by expanding them to their concrete implementations.

Bug Fixes:
- Allow Django error-handled mutations returning interfaces to resolve their concrete object implementations correctly.

Tests:
- Add focused coverage for mutation fields returning interfaces with Django error handling.