### PR TITLE
fix: LOOKUP_SEP boundary when recovering select_related

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ release type: patch
 
 Fix the query optimizer dropping a manually applied `select_related` from the
 `only()` mask when another field on the same model shares its name as a
-prefix without a `__` boundary (e.g. `empresa` vs `empresa_comercial`). This
+prefix without a `__` boundary (e.g. `company` vs `company_branch`). This
 previously made Django raise `FieldError: cannot be both deferred and
 traversed using select_related at the same time` whenever only the longer
 sibling was selected in the query.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+---
+release type: patch
+---
+
+Fix the query optimizer dropping a manually applied `select_related` from the
+`only()` mask when another field on the same model shares its name as a
+prefix without a `__` boundary (e.g. `empresa` vs `empresa_comercial`). This
+previously made Django raise `FieldError: cannot be both deferred and
+traversed using select_related at the same time` whenever only the longer
+sibling was selected in the query.

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -469,7 +469,9 @@ class OptimizerStore:
                 if select_related in only_set:
                     continue
 
-                if not any(only.startswith(select_related) for only in only_set):
+                if not any(
+                    _is_relation_path_covered(only, select_related) for only in only_set
+                ):
                     extra_only_set.add(select_related)
 
         return qs, extra_only_set
@@ -509,6 +511,15 @@ class OptimizerStore:
             to_annotate[k] = v
 
         return qs.annotate(**to_annotate)
+
+
+def _is_relation_path_covered(candidate: str, target: str) -> bool:
+    """Whether `candidate` is `target` itself or a `LOOKUP_SEP`-bounded descendant of it.
+
+    A plain `candidate.startswith(target)` is wrong: e.g. "empresa_comercial"
+    starts with "empresa" even though they're unrelated sibling fields.
+    """
+    return candidate == target or candidate.startswith(f"{target}{LOOKUP_SEP}")
 
 
 def _create_strawberry_info(raw_info: GraphQLResolveInfo) -> Info:
@@ -1078,11 +1089,10 @@ def _store_declares_select_related(
     if not field_store:
         return False
 
-    for sr in field_store.select_related:
-        if sr == relation_name or sr.startswith(f"{relation_name}{LOOKUP_SEP}"):
-            return True
-
-    return False
+    return any(
+        _is_relation_path_covered(sr, relation_name)
+        for sr in field_store.select_related
+    )
 
 
 def _get_hints_from_django_field(
@@ -1223,7 +1233,10 @@ def _get_hints_from_django_field(
         store = OptimizerStore.with_hints(only=[path])
         if relation_prefix:
             relation_path = f"{lookup_prefix}{relation_prefix}"
-            if not any(sr.startswith(relation_path) for sr in store.select_related):
+            if not any(
+                _is_relation_path_covered(sr, relation_path)
+                for sr in store.select_related
+            ):
                 store.select_related.append(relation_path)
 
     return store

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -433,7 +433,7 @@ class OptimizerStore:
         self,
         qs: QuerySet[_M],
         *,
-        info: GraphQLResolveInfo,
+        info: GraphQLResolveInfo | None,
         config: OptimizerConfig,
     ) -> tuple[QuerySet[_M], set[str]]:
         only_set = set(self.only)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -22,6 +22,8 @@ from strawberry.types import ExecutionResult, Info, get_object_definition
 import strawberry_django
 from strawberry_django.optimizer import (
     DjangoOptimizerExtension,
+    OptimizerConfig,
+    OptimizerStore,
 )
 from tests.projects.schema import IssueType, MilestoneType, ProjectType, StaffType
 
@@ -1223,6 +1225,29 @@ def test_query_select_related_without_only(db, gql_client: GraphQLTestClient):
             "milestoneNameWithoutOnlyOptimization": milestone.name,
         },
     }
+
+
+def test_apply_select_related_requires_lookup_sep_boundary():
+    """A `select_related` path must only count as covered by a matching `only` entry.
+
+    The entry must be that path itself or a `__`-bounded descendant of it.
+    A raw prefix match wrongly treats "milestone_x" as covering "milestone",
+    which drops "milestone" from the recovered only() set and makes Django
+    raise "cannot be both deferred and traversed using select_related at
+    the same time" once the query runs.
+    """
+    store = OptimizerStore.with_hints(
+        only=["milestone_x"],
+        select_related=["milestone"],
+    )
+
+    _, extra_only_set = store._apply_select_related(
+        Issue.objects.all(),
+        info=None,
+        config=OptimizerConfig(),
+    )
+
+    assert extra_only_set == {"milestone"}
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1250,6 +1250,34 @@ def test_apply_select_related_requires_lookup_sep_boundary():
     assert extra_only_set == {"milestone"}
 
 
+@pytest.mark.parametrize(
+    "only",
+    [
+        pytest.param(["milestone"], id="exact_match"),
+        pytest.param(["milestone__project"], id="lookup_sep_bounded_descendant"),
+    ],
+)
+def test_apply_select_related_covered_by_only(only):
+    """A `select_related` path covered by a matching `only` entry adds nothing extra.
+
+    Covered means the `only` entry is the `select_related` path itself, or a
+    descendant of it bounded by `LOOKUP_SEP` (e.g. "milestone__project" covers
+    "milestone").
+    """
+    store = OptimizerStore.with_hints(
+        only=only,
+        select_related=["milestone"],
+    )
+
+    _, extra_only_set = store._apply_select_related(
+        Issue.objects.all(),
+        info=None,
+        config=OptimizerConfig(),
+    )
+
+    assert extra_only_set == set()
+
+
 @pytest.mark.django_db(transaction=True)
 def test_handles_existing_select_related(db, gql_client: GraphQLTestClient):
     """select_related should not cause errors, even if the field does not get queried."""

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 import pytest
 import strawberry
-from django.db import DEFAULT_DB_ALIAS, connections
+from django.db import DEFAULT_DB_ALIAS, connections, models
 from django.db.models import (
     CharField,
     Expression,
@@ -28,6 +28,7 @@ from strawberry_django.optimizer import (
 from tests.projects.schema import IssueType, MilestoneType, ProjectType, StaffType
 
 from . import utils
+from .models import Fruit
 from .projects.faker import (
     IssueFactory,
     MilestoneFactory,
@@ -1276,6 +1277,347 @@ def test_apply_select_related_covered_by_only(only):
     )
 
     assert extra_only_set == set()
+
+
+def test_apply_select_related_fk_attname_still_covers_relation():
+    """A FK attname (`color_id`) in `only()` is no longer treated as covering `select_related("color")`.
+
+    Unlike "empresa"/"empresa_comercial", this is not a random prefix
+    collision: `color_id` is the FK column backing the `color` relation
+    itself. Post-fix, `color` gets redundantly re-added to `only()`; this
+    confirms that's harmless rather than a silent behavior change.
+    """
+    store = OptimizerStore.with_hints(
+        only=["color_id"],
+        select_related=["color"],
+    )
+
+    _, extra_only_set = store._apply_select_related(
+        Fruit.objects.all(),
+        info=None,
+        config=OptimizerConfig(),
+    )
+
+    assert extra_only_set == {"color"}
+
+
+# Throwaway models for the LOOKUP_SEP boundary flows below: no model in the
+# shared test schema has a field name that is a string-prefix of a sibling
+# field name, so a real end-to-end repro needs models built for the purpose.
+class QAEmpresa(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    nombre = CharField(max_length=50)
+
+
+class QAEmpresaComercial(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    nombre = CharField(max_length=50)
+
+
+class QAFactura(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    numero = CharField(max_length=50)
+    empresa = models.ForeignKey(
+        QAEmpresa, on_delete=models.CASCADE, related_name="facturas"
+    )
+    empresa_comercial = models.ForeignKey(
+        QAEmpresaComercial, on_delete=models.CASCADE, related_name="facturas"
+    )
+
+
+def _create_qa_factura():
+    empresa = QAEmpresa.objects.create(nombre="E")
+    comercial = QAEmpresaComercial.objects.create(nombre="C")
+    return QAFactura.objects.create(
+        numero="F1", empresa=empresa, empresa_comercial=comercial
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_select_related_field_hint_survives_prefix_colliding_sibling(db):
+    """A manual `select_related` field hint must survive a prefix-colliding sibling.
+
+    "empresa" and "empresa_comercial" are sibling FKs on the same model.
+    Without the LOOKUP_SEP boundary check, only()'s recovery logic treats
+    "empresa_comercial" as already covering "empresa" and never re-adds
+    it, so Django raises "cannot be both deferred and traversed using
+    select_related at the same time".
+    """
+
+    @strawberry_django.type(QAEmpresaComercial)
+    class EmpresaComercialType:
+        nombre: strawberry.auto
+
+    @strawberry_django.type(QAFactura)
+    class FacturaType:
+        numero: strawberry.auto
+        empresa_comercial: EmpresaComercialType
+
+        @strawberry_django.field(select_related="empresa")
+        def empresa_nombre(self) -> str:
+            return self.empresa.nombre  # type: ignore
+
+    @strawberry.type
+    class Query:
+        facturas: list[FacturaType] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
+
+    _create_qa_factura()
+
+    query = "{ facturas { numero empresaNombre empresaComercial { nombre } } }"
+    result = schema.execute_sync(query)
+
+    assert result.errors is None, result.errors
+    assert result.data == {
+        "facturas": [
+            {"numero": "F1", "empresaNombre": "E", "empresaComercial": {"nombre": "C"}},
+        ],
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_select_related_via_get_queryset_survives_prefix_colliding_sibling(db):
+    """The boundary check also applies when `select_related` is applied on the queryset directly.
+
+    Exercises the `qs.query.select_related` dict-based code path, distinct
+    from the field-hint route in the test above.
+    """
+
+    @strawberry_django.type(QAEmpresaComercial)
+    class EmpresaComercialType:
+        nombre: strawberry.auto
+
+    @strawberry_django.type(QAFactura)
+    class FacturaType:
+        numero: strawberry.auto
+        empresa_comercial: EmpresaComercialType
+
+        @classmethod
+        def get_queryset(cls, queryset, info, **kwargs):
+            return queryset.select_related("empresa")
+
+    @strawberry.type
+    class Query:
+        facturas: list[FacturaType] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
+
+    _create_qa_factura()
+
+    query = "{ facturas { numero empresaComercial { nombre } } }"
+    result = schema.execute_sync(query)
+
+    assert result.errors is None, result.errors
+    assert result.data == {
+        "facturas": [{"numero": "F1", "empresaComercial": {"nombre": "C"}}],
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+def test_no_manual_select_related_on_prefix_colliding_sibling_is_unaffected(db):
+    """Without a manual `select_related` hint, a prefix-colliding sibling name changes nothing.
+
+    Isolates that the failures the tests above guard against come from the
+    boundary check specifically, not from the model shape on its own.
+    """
+
+    @strawberry_django.type(QAEmpresaComercial)
+    class EmpresaComercialType:
+        nombre: strawberry.auto
+
+    @strawberry_django.type(QAFactura)
+    class FacturaType:
+        numero: strawberry.auto
+        empresa_comercial: EmpresaComercialType
+
+    @strawberry.type
+    class Query:
+        facturas: list[FacturaType] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
+
+    _create_qa_factura()
+
+    query = "{ facturas { numero empresaComercial { nombre } } }"
+    with assert_num_queries(1):
+        result = schema.execute_sync(query)
+
+    assert result.errors is None, result.errors
+
+
+class QAPais(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    nombre = CharField(max_length=50)
+
+
+class QAPaisOrigen(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    nombre = CharField(max_length=50)
+
+
+class QAEmpresaN(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    nombre = CharField(max_length=50)
+    pais = models.ForeignKey(QAPais, on_delete=models.CASCADE, related_name="empresas")
+    pais_origen = models.ForeignKey(
+        QAPaisOrigen, on_delete=models.CASCADE, related_name="empresas"
+    )
+
+
+class QAFacturaN(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    numero = CharField(max_length=50)
+    empresa = models.ForeignKey(
+        QAEmpresaN, on_delete=models.CASCADE, related_name="facturas"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_select_related_boundary_holds_at_nested_depth(db):
+    """The LOOKUP_SEP boundary check must hold below the top level too.
+
+    "empresa__pais" and "empresa__pais_origen" collide on their last
+    segment the same way "empresa"/"empresa_comercial" do at the top
+    level, one level deeper than the existing unit tests cover.
+    """
+
+    @strawberry_django.type(QAPaisOrigen)
+    class PaisOrigenType:
+        nombre: strawberry.auto
+
+    @strawberry_django.type(QAEmpresaN)
+    class EmpresaNType:
+        nombre: strawberry.auto
+        pais_origen: PaisOrigenType
+
+    @strawberry_django.type(QAFacturaN)
+    class FacturaNType:
+        numero: strawberry.auto
+        empresa: EmpresaNType
+
+        @strawberry_django.field(select_related="empresa__pais")
+        def pais_nombre(self) -> str:
+            return self.empresa.pais.nombre  # type: ignore
+
+    @strawberry.type
+    class Query:
+        facturas: list[FacturaNType] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
+
+    pais = QAPais.objects.create(nombre="P")
+    pais_origen = QAPaisOrigen.objects.create(nombre="PO")
+    empresa = QAEmpresaN.objects.create(nombre="E", pais=pais, pais_origen=pais_origen)
+    QAFacturaN.objects.create(numero="F1", empresa=empresa)
+
+    query = (
+        "{ facturas { numero paisNombre empresa { nombre paisOrigen { nombre } } } }"
+    )
+    result = schema.execute_sync(query)
+
+    assert result.errors is None, result.errors
+    assert result.data == {
+        "facturas": [
+            {
+                "numero": "F1",
+                "paisNombre": "P",
+                "empresa": {"nombre": "E", "paisOrigen": {"nombre": "PO"}},
+            },
+        ],
+    }
+
+
+class QAEmpresaD(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    nombre = CharField(max_length=50)
+    lema = CharField(max_length=50, default="")
+
+
+class QAEmpresaComercialD(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    nombre = CharField(max_length=50)
+
+
+class QAFacturaD(models.Model):
+    class Meta:
+        app_label = "tests"
+
+    numero = CharField(max_length=50)
+    empresa = models.ForeignKey(
+        QAEmpresaD, on_delete=models.CASCADE, related_name="facturas"
+    )
+    empresa_comercial = models.ForeignKey(
+        QAEmpresaComercialD, on_delete=models.CASCADE, related_name="facturas"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_store_declares_select_related_respects_boundary(db):
+    """A resolver's own `select_related` hint must not mask its field name's real relation.
+
+    The `empresa` method resolver declares select_related=["empresa_comercial"],
+    a sibling that merely starts with "empresa". `_store_declares_select_related`
+    must still treat "empresa" itself as undeclared and select_related it,
+    or the query falls back to N+1 lazy loads instead of one JOIN-backed
+    query. Pre-fix code was already boundary-correct at this call site, so
+    this is a regression guard for the refactor, not a bug repro.
+    """
+
+    @strawberry_django.type(QAEmpresaD)
+    class EmpresaDType:
+        nombre: strawberry.auto
+
+        @strawberry_django.field(only=["lema"])
+        def extra(self) -> str:
+            return self.lema  # type: ignore
+
+    @strawberry_django.type(QAFacturaD)
+    class FacturaDType:
+        numero: strawberry.auto
+
+        @strawberry_django.field(select_related=["empresa_comercial"])
+        def empresa(self) -> EmpresaDType | None:
+            return getattr(self, "empresa", None)
+
+    @strawberry.type
+    class Query:
+        facturas: list[FacturaDType] = strawberry_django.field()
+
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
+
+    empresa = QAEmpresaD.objects.create(nombre="E", lema="L")
+    comercial = QAEmpresaComercialD.objects.create(nombre="C")
+    QAFacturaD.objects.create(numero="F1", empresa=empresa, empresa_comercial=comercial)
+
+    query = "{ facturas { numero empresa { extra } } }"
+
+    with CaptureQueriesContext(connection=connections[DEFAULT_DB_ALIAS]) as ctx:
+        result = schema.execute_sync(query)
+
+    assert result.errors is None, result.errors
+    assert result.data == {
+        "facturas": [{"numero": "F1", "empresa": {"extra": "L"}}],
+    }
+    assert len(ctx.captured_queries) == 3, ctx.captured_queries
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Fixes #938.

<div>
    <a href="https://www.loom.com/share/d689f6e1ed404d5ea102c15b837c9d26">
      <p>strawberry-django PR 945 fix: LOOKUP_SEP boundary when recovering select_related - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/d689f6e1ed404d5ea102c15b837c9d26">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/d689f6e1ed404d5ea102c15b837c9d26-f79579dcc6f5afaa-full-play.gif#t=0.1">
    </a>
  </div>

`_apply_select_related` checked whether a manual `select_related` path was covered by an `only()` entry via a raw `only.startswith(select_related)`. Without a `__` boundary, a sibling field sharing the same prefix (e.g. `empresa` vs `empresa_comercial`) was wrongly treated as covering it, so the shorter relation never got re-added to `only()`. Django then raised "cannot be both deferred and traversed using select_related at the same time".

Factored the check into a shared `_is_relation_path_covered` helper, reused at two other call sites with the same shape (one already correct, one with the identical bug).

Correction: the third call site touched by this refactor (`_get_hints_from_django_field`) is unreachable as a live bug. `store.select_related` is always empty at that check, so the guard is vacuous both before and after this change. That change is a no-op refactor for consistency, not a bug fix.

### Tests
- Unit tests pin the boundary semantics directly against `OptimizerStore._apply_select_related` (exact match, descendant, sibling-prefix).
- New end-to-end GraphQL tests cover the bug against real queries: the field-hint `select_related` route, the queryset `select_related` route, a nested-depth collision, a negative control, the `_store_declares_select_related` call site, and a regression guard for FK attname vs relation name in `only()`.
- Full suite: 1247 passed, 6 skipped. `ruff` lint + format clean.

## Summary by Sourcery

Preserve manually selected related fields when recovering `only()` masks by requiring exact or lookup-separator-bounded path matches.

Bug Fixes:
- Prevent relation paths that merely share a string prefix from being treated as covered by `only()`, avoiding invalid deferred and `select_related` combinations.

Enhancements:
- Centralize relation-path coverage checks with lookup-separator boundary semantics and reuse them across optimizer call sites.

Tests:
- Add regression coverage for exact, descendant, and sibling-prefix relation paths.

## Summary by Sourcery

Fix relation-path coverage in the query optimizer so only lookup-separator-bounded matches satisfy manually applied `select_related` paths.

Bug Fixes:
- Preserve manually selected related fields in recovered `only()` masks when field names share a string prefix without a lookup-separator boundary, preventing invalid deferred and `select_related` combinations.

Enhancements:
- Centralize relation-path coverage checks and apply consistent exact-or-lookup-bounded descendant semantics across optimizer call sites.

Tests:
- Add unit and end-to-end regression coverage for exact matches, bounded descendants, sibling-prefix collisions, nested paths, queryset and field-hint routes, and foreign-key attnames.