### PR TITLE
fix: reuse generated permission directive classes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+---
+release type: patch
+---
+
+Reuse generated permission directive classes so schemas with repeated permission extensions remain valid with Strawberry 0.326.0 and later.

--- a/strawberry_django/permissions.py
+++ b/strawberry_django/permissions.py
@@ -280,7 +280,7 @@ class DjangoPermissionExtension(FieldExtension, abc.ABC):
     @functools.cached_property
     def schema_directive(self) -> object:
         key = "__strawberry_directive_type__"
-        directive_class = getattr(self.__class__, key, None)
+        directive_class = self.__class__.__dict__.get(key)
 
         if directive_class is None:
 
@@ -293,6 +293,7 @@ class DjangoPermissionExtension(FieldExtension, abc.ABC):
             class AutoDirective: ...
 
             directive_class = AutoDirective
+            setattr(self.__class__, key, directive_class)
 
         return directive_class()
 
@@ -692,7 +693,7 @@ class HasPerm(DjangoPermissionExtension):
     @functools.cached_property
     def schema_directive(self) -> object:
         key = "__strawberry_directive_class__"
-        directive_class = getattr(self.__class__, key, None)
+        directive_class = self.__class__.__dict__.get(key)
 
         if directive_class is None:
 
@@ -713,6 +714,7 @@ class HasPerm(DjangoPermissionExtension):
                 )
 
             directive_class = AutoDirective
+            setattr(self.__class__, key, directive_class)
 
         return directive_class(
             permissions=list(self.perms),

--- a/tests/test_field_permissions.py
+++ b/tests/test_field_permissions.py
@@ -7,7 +7,15 @@ from strawberry import BasePermission, Info
 
 import strawberry_django
 from strawberry_django.optimizer import DjangoOptimizerExtension
+from strawberry_django.permissions import HasPerm, IsSuperuser
 from tests import models
+
+
+def test_permission_directive_classes_are_reused():
+    assert type(IsSuperuser().schema_directive) is type(IsSuperuser().schema_directive)
+    assert type(HasPerm("auth.view_user").schema_directive) is type(
+        HasPerm("auth.view_user").schema_directive
+    )
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Closes #948.

## Summary

- cache each generated permission directive class on its extension class
- keep subclass directive caches isolated instead of inheriting a parent class cache
- cover both standard permission extensions and `HasPerm`

## Validation

- `uv run --with strawberry-graphql==0.326.0 pytest tests/test_permissions.py tests/test_field_permissions.py -q --no-cov` (163 passed, 2 skipped)
- `uv run ruff check strawberry_django/permissions.py tests/test_field_permissions.py`
- `uv run ruff format --check strawberry_django/permissions.py tests/test_field_permissions.py`
- `uv run --with pyright pyright strawberry_django/permissions.py`
- `git diff --check`

## Risk boundary

The change only affects construction-time caching of generated permission directive classes. Permission evaluation and directive instance values are unchanged.

## Summary by Sourcery

Cache generated permission directive classes per permission extension class to support repeated schema permission extensions.

Bug Fixes:
- Reuse generated permission directive classes so repeated permission extensions remain valid with Strawberry 0.326.0 and later.

Enhancements:
- Keep generated directive class caches isolated between permission extension subclasses.

Tests:
- Add coverage confirming directive classes are reused for standard permissions and HasPerm.