### PR TITLE
fix: do not fetch entire table for nullable connection queries

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+---
+release type: patch
+---
+
+Fix nullable connections (e.g. when guarded by a permission extension) eagerly
+fetching the entire table before the connection applied its pagination. The
+return type is now unwrapped from `StrawberryOptional`/other containers so the
+queryset evaluation stays deferred and the connection can apply a `LIMIT`.

--- a/strawberry_django/relay/utils.py
+++ b/strawberry_django/relay/utils.py
@@ -13,6 +13,7 @@ from asgiref.sync import sync_to_async
 from django.db import models
 from strawberry import relay
 from strawberry.relay.exceptions import NodeIDAnnotationError
+from strawberry.types.base import StrawberryContainer
 from strawberry.types.info import Info
 from strawberry.utils.await_maybe import AwaitableOrValue
 
@@ -161,6 +162,9 @@ def resolve_model_nodes(
         # Connection will filter the results when its is being resolved.
         # We don't want to fetch everything before it does that
         return_type = info.return_type
+        # Unwrap containers (e.g. `StrawberryOptional` for a nullable connection)
+        while isinstance(return_type, StrawberryContainer):
+            return_type = return_type.of_type
         if isinstance(return_type, type) and issubclass(return_type, relay.Connection):
             extra_args["qs_hook"] = lambda qs: qs
 

--- a/tests/relay/schema.py
+++ b/tests/relay/schema.py
@@ -58,6 +58,8 @@ class Query:
     node_optional: relay.Node | None = strawberry_django.node()
     nodes_optional: list[relay.Node | None] = strawberry_django.node()
     fruits: DjangoListConnection[Fruit] = strawberry_django.connection()
+    # Nullable connection (e.g. as produced by a permission extension)
+    fruits_optional: DjangoListConnection[Fruit] | None = strawberry_django.connection()
     fruits_lazy: DjangoListConnection[
         Annotated["Fruit", strawberry.lazy("tests.relay.schema")]
     ] = strawberry_django.connection()

--- a/tests/relay/snapshots/schema.gql
+++ b/tests/relay/snapshots/schema.gql
@@ -104,6 +104,19 @@ type Query {
     """Returns the items in the list that come after the specified cursor."""
     last: Int = null
   ): FruitConnection!
+  fruitsOptional(
+    """Returns the items in the list that come before the specified cursor."""
+    before: String = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String = null
+
+    """Returns the first n items from the list."""
+    first: Int = null
+
+    """Returns the items in the list that come after the specified cursor."""
+    last: Int = null
+  ): FruitConnection
   fruitsLazy(
     """Returns the items in the list that come before the specified cursor."""
     before: String = null

--- a/tests/relay/test_fields.py
+++ b/tests/relay/test_fields.py
@@ -1,4 +1,6 @@
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from pytest_django import DjangoAssertNumQueries
 from strawberry.relay.utils import to_base64
 
@@ -1177,3 +1179,35 @@ def test_query_connection_total_count_sql_queries(
     assert result.data == {
         query_attr: {"totalCount": 5},
     }
+
+
+def test_nullable_connection_does_not_fetch_whole_table():
+    # Regression test: a nullable connection (e.g. wrapped in `StrawberryOptional`
+    # by a permission extension) used to fetch the entire table before the
+    # connection sliced the results, because the return type was not unwrapped
+    # and the queryset was evaluated eagerly instead of being deferred with a
+    # LIMIT applied by the connection.
+    with CaptureQueriesContext(connection) as ctx:
+        result = schema.execute_sync(
+            """
+            query {
+                fruitsOptional (first: 2) {
+                    edges {
+                        node { id name }
+                    }
+                }
+            }
+            """,
+        )
+
+    assert result.errors is None
+    assert result.data is not None
+    edges = result.data["fruitsOptional"]["edges"]
+    assert len(edges) == 2
+
+    # The query that fetches the fruit rows must use a LIMIT so it doesn't
+    # pull the entire table into memory.
+    fetch_queries = [
+        q["sql"] for q in ctx.captured_queries if "fruit" in q["sql"].lower()
+    ]
+    assert any("LIMIT 3" in sql for sql in fetch_queries), fetch_queries


### PR DESCRIPTION
## Description

A nullable connection (e.g. one guarded by a permission extension) has an `info.return_type` wrapped in `StrawberryOptional`, so the `issubclass` check against `relay.Connection` failed and the queryset was evaluated eagerly via the default `qs_hook`, fetching the entire table before the connection applied its pagination.

Unwrap containers from the return type before the check so the queryset evaluation stays deferred and the connection can apply a `LIMIT`.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Preserve deferred queryset evaluation for nullable connections so pagination limits database reads.

Bug Fixes:
- Prevent nullable autogenerated connections from eagerly fetching the entire table before pagination is applied.

Tests:
- Add regression coverage verifying nullable connection queries apply a database LIMIT.