### PR TITLE
Require Strawberry 0.322.2 and update GraphQL compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
           if [ "${{ matrix.gql-core }}" = "3.2" ]; then
             uv pip install "graphql-core>=3.2.0,<3.3.0"
           else
-            uv pip install "graphql-core==3.3.0a12"
+            uv pip install "graphql-core==3.3.0rc0"
           fi
       - name: Test with pytest
         run: uv run --no-sync pytest -n auto --showlocals -vvv --cov-report=xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ def schema_directive(self) -> object:
     directive_class = self.__class__.__dict__.get(key)
 
     if directive_class is None:
+
         @schema_directive(
             name=self.__class__.__name__,
             locations=self.SCHEMA_DIRECTIVE_LOCATIONS,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+---
+release type: minor
+---
+
+Require Strawberry GraphQL 0.322.2 or newer, which fixes Relay pagination when combining `first` with `before`. Update compatibility tests for the corrected pagination behavior and make schema comparisons independent of top-level definition order.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,3 +3,5 @@ release type: minor
 ---
 
 Require Strawberry GraphQL 0.322.2 or newer, which fixes Relay pagination when combining `first` with `before`. Update compatibility tests for the corrected pagination behavior and make schema comparisons independent of top-level definition order.
+
+Update GraphQL-core 3.3 compatibility for the 3.3.0rc0 execution API, preserving resolve-info context and adapting fragment and variable values used by the query optimizer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Framework :: Django :: 6.0",
 ]
 requires-python = ">=3.10,<4.0"
-dependencies = ["django>=5.2", "asgiref>=3.8", "strawberry-graphql>=0.310.1"]
+dependencies = ["django>=5.2", "asgiref>=3.8", "strawberry-graphql>=0.322.2"]
 
 [project.urls]
 homepage = "https://strawberry.rocks/docs/django"

--- a/strawberry_django/optimizer.py
+++ b/strawberry_django/optimizer.py
@@ -31,7 +31,6 @@ from graphql import (
     GraphQLObjectType,
     GraphQLOutputType,
     GraphQLWrappingType,
-    get_argument_values,
 )
 from graphql.language.ast import OperationType
 from graphql.type.definition import GraphQLResolveInfo, get_named_type
@@ -53,7 +52,7 @@ from strawberry_django.relay.list_connection import DjangoListConnection
 from strawberry_django.resolvers import django_fetch
 
 from .descriptors import ModelProperty
-from .utils.gql_compat import get_sub_field_selections
+from .utils.gql_compat import get_field_arguments, get_sub_field_selections
 from .utils.inspect import (
     PrefetchInspector,
     get_model_field,
@@ -620,10 +619,10 @@ def _optimize_prefetch_queryset(
         field=field,
         source=None,
         info=field_info,
-        kwargs=get_argument_values(
+        kwargs=get_field_arguments(
+            info,
             parent_type.fields[field_name],
             field_node,
-            info.variable_values,
         ),
         config=strawberry_schema.config,
         scalar_registry=strawberry_schema.schema_converter.scalar_registry,
@@ -735,19 +734,12 @@ def _generate_selection_resolve_info(
     parent_type: GraphQLObjectType | GraphQLInterfaceType,
 ):
     field_node = field_nodes[0]
-    return GraphQLResolveInfo(
+    return info._replace(
         field_name=field_node.name.value,
         field_nodes=field_nodes,
         return_type=return_type,
         parent_type=cast("GraphQLObjectType", parent_type),
         path=info.path.add_key(0).add_key(field_node.name.value, parent_type.name),
-        schema=info.schema,
-        fragments=info.fragments,
-        root_value=info.root_value,
-        operation=info.operation,
-        variable_values=info.variable_values,
-        context=info.context,
-        is_awaitable=info.is_awaitable,
     )
 
 

--- a/strawberry_django/utils/gql_compat.py
+++ b/strawberry_django/utils/gql_compat.py
@@ -6,8 +6,10 @@ from typing import TYPE_CHECKING, Any, cast
 
 from graphql import (
     FieldNode,
+    GraphQLField,
     GraphQLInterfaceType,
     GraphQLObjectType,
+    get_argument_values,
 )
 from graphql.version import VersionInfo, version_info
 
@@ -16,6 +18,24 @@ if TYPE_CHECKING:
 
 IS_GQL_33 = version_info >= VersionInfo.from_str("3.3.0a0")
 IS_GQL_32 = not IS_GQL_33
+
+
+def _get_variable_values(info: GraphQLResolveInfo) -> Any:
+    if IS_GQL_32:
+        return info.variable_values
+
+    from graphql.execution.values import VariableValues  # type: ignore
+
+    # Strawberry exposes the coerced variables as a dict on resolve info.
+    return VariableValues(sources={}, coerced=info.variable_values)
+
+
+def get_field_arguments(
+    info: GraphQLResolveInfo,
+    field: GraphQLField,
+    node: FieldNode,
+) -> dict[str, Any]:
+    return get_argument_values(field, node, _get_variable_values(info))
 
 
 def get_sub_field_selections(
@@ -51,6 +71,7 @@ def _get_selections_gql33(
 ) -> dict[str, list[FieldNode]]:
     from graphql.execution.collect_fields import (
         FieldDetails,  # type: ignore
+        FragmentDetails,  # type: ignore
         collect_subfields,  # type: ignore
     )
 
@@ -60,8 +81,8 @@ def _get_selections_gql33(
 
     collected = collect_subfields(
         info.schema,
-        info.fragments,
-        info.variable_values,
+        {name: FragmentDetails(fragment) for name, fragment in info.fragments.items()},
+        _get_variable_values(info),
         info.operation,
         cast("GraphQLObjectType", parent_type),
         field_group,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def schema(request):
         tags: list[types.Tag] = strawberry_django.field()
 
     if request.param == "optimizer_enabled":
-        extensions = [DjangoOptimizerExtension()]
+        extensions = [DjangoOptimizerExtension]
     elif request.param == "optimizer_disabled":
         extensions = []
     else:

--- a/tests/extensions/test_validation_cache.py
+++ b/tests/extensions/test_validation_cache.py
@@ -20,7 +20,7 @@ def test_validation_cache_extension(mock_validate):
         def ping(self) -> str:
             return "pong"
 
-    schema = strawberry.Schema(query=Query, extensions=[DjangoValidationCache()])
+    schema = strawberry.Schema(query=Query, extensions=[DjangoValidationCache])
 
     query = "query { hello }"
 

--- a/tests/federation/test_resolve_reference.py
+++ b/tests/federation/test_resolve_reference.py
@@ -191,7 +191,7 @@ def test_resolve_reference_uses_optimizer_extension():
     schema = FederationSchema(
         query=Query,
         types=[FruitType],
-        extensions=[RecordingOptimizerExtension()],
+        extensions=[RecordingOptimizerExtension],
     )
 
     fruit = models.Fruit.objects.create(name="optimized-fruit")

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -682,7 +682,7 @@ def test_entities_resolver_with_optimizer():
     schema = FederationSchema(
         query=Query,
         types=[FruitType],
-        extensions=[DjangoOptimizerExtension()],
+        extensions=[DjangoOptimizerExtension],
     )
 
     fruit = models.Fruit.objects.create(name="optimized")
@@ -732,7 +732,7 @@ def test_entities_resolver_with_optimizer_and_fk():
     schema = FederationSchema(
         query=Query,
         types=[FruitType, ColorType],
-        extensions=[DjangoOptimizerExtension()],
+        extensions=[DjangoOptimizerExtension],
     )
 
     color = models.Color.objects.create(name="yellow")

--- a/tests/projects/test_schema.py
+++ b/tests/projects/test_schema.py
@@ -15,9 +15,8 @@ SNAPSHOTS_DIR = pathlib.Path(__file__).parent / "snapshots"
 
 
 def test_schema():
-    # Directive argument types moved into the sorted type map in Strawberry
-    # 0.326.0. Compare definitions without depending on their printed order;
-    # fields, arguments, descriptions and directive applications still match.
+    # Ignore top-level definition order while preserving checks for fields,
+    # arguments, descriptions, and directive applications.
     actual = parse(normalize_sdl(str(schema)), no_location=True)
     expected = parse(
         normalize_sdl((SNAPSHOTS_DIR / "schema.gql").read_text()), no_location=True

--- a/tests/projects/test_schema.py
+++ b/tests/projects/test_schema.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import strawberry
+from graphql import parse
 from pytest_snapshot.plugin import Snapshot
 
 import strawberry_django
@@ -13,9 +14,21 @@ from .schema import IssueInput, IssueType, MilestoneType, ProjectType, schema
 SNAPSHOTS_DIR = pathlib.Path(__file__).parent / "snapshots"
 
 
-def test_schema(snapshot: Snapshot):
-    snapshot.snapshot_dir = SNAPSHOTS_DIR
-    snapshot.assert_match(normalize_sdl(str(schema)), "schema.gql")
+def test_schema():
+    # Directive argument types moved into the sorted type map in Strawberry
+    # 0.326.0. Compare definitions without depending on their printed order;
+    # fields, arguments, descriptions and directive applications still match.
+    actual = parse(normalize_sdl(str(schema)), no_location=True)
+    expected = parse(
+        normalize_sdl((SNAPSHOTS_DIR / "schema.gql").read_text()), no_location=True
+    )
+
+    def definition_key(definition):
+        return definition.kind, getattr(getattr(definition, "name", None), "value", "")
+
+    assert sorted(actual.definitions, key=definition_key) == sorted(
+        expected.definitions, key=definition_key
+    )
 
 
 def test_schema_with_inheritance(snapshot: Snapshot):

--- a/tests/relay/test_cursor_pagination.py
+++ b/tests/relay/test_cursor_pagination.py
@@ -92,7 +92,7 @@ class Query:
         return cast("list[ProjectType]", Project.objects.all().order_by("-pk"))
 
 
-schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension()])
+schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
 
 
 @pytest.fixture
@@ -1555,7 +1555,7 @@ def test_connection_distinct_with_m2m_filters():
         fruits: DjangoCursorConnection[FruitGQL] = strawberry_django.connection()
 
     fruit_schema = strawberry.Schema(
-        query=FruitQuery, extensions=[DjangoOptimizerExtension()]
+        query=FruitQuery, extensions=[DjangoOptimizerExtension]
     )
 
     ft1 = models.FruitType.objects.create(name="tropical")
@@ -1628,7 +1628,7 @@ def test_connection_distinct_with_pagination():
         fruits: DjangoCursorConnection[FruitGQL] = strawberry_django.connection()
 
     fruit_schema = strawberry.Schema(
-        query=FruitQuery, extensions=[DjangoOptimizerExtension()]
+        query=FruitQuery, extensions=[DjangoOptimizerExtension]
     )
 
     ft1 = models.FruitType.objects.create(name="tropical")

--- a/tests/relay/test_fields.py
+++ b/tests/relay/test_fields.py
@@ -1,17 +1,10 @@
-from importlib.metadata import version
-
 import pytest
-from packaging.version import Version
 from pytest_django import DjangoAssertNumQueries
 from strawberry.relay.utils import to_base64
 
 from .schema import FruitModel, schema
 
 pytestmark = pytest.mark.usefixtures("_fixtures")
-
-# Strawberry 0.322.2 corrected first+before to select from the start of the
-# bounded connection. Keep coverage for the older supported releases as well.
-FIRST_BEFORE_FIXED = Version(version("strawberry-graphql")) >= Version("0.322.2")
 
 
 @pytest.fixture
@@ -712,26 +705,24 @@ def test_query_connection_filtering_first_with_before(query_attr: str):
         fruits_query.format(query_attr),
         variable_values={"first": 1, "before": to_base64("arrayconnection", "3")},
     )
-    index = 0 if FIRST_BEFORE_FIXED else 2
-    name = "Banana" if FIRST_BEFORE_FIXED else "Pineapple"
     assert result.errors is None
     assert result.data == {
         query_attr: {
             "edges": [
                 {
-                    "cursor": to_base64("arrayconnection", str(index)),
+                    "cursor": to_base64("arrayconnection", "0"),
                     "node": {
-                        "id": to_base64("Fruit", index + 1),
+                        "id": to_base64("Fruit", 1),
                         "color": "yellow",
-                        "name": name,
+                        "name": "Banana",
                     },
                 },
             ],
             "pageInfo": {
                 "hasNextPage": True,
-                "hasPreviousPage": not FIRST_BEFORE_FIXED,
-                "startCursor": to_base64("arrayconnection", str(index)),
-                "endCursor": to_base64("arrayconnection", str(index)),
+                "hasPreviousPage": False,
+                "startCursor": to_base64("arrayconnection", "0"),
+                "endCursor": to_base64("arrayconnection", "0"),
             },
         },
     }
@@ -743,26 +734,24 @@ async def test_query_connection_filtering_first_with_before_async(query_attr: st
         fruits_query.format(query_attr),
         variable_values={"first": 1, "before": to_base64("arrayconnection", "3")},
     )
-    index = 0 if FIRST_BEFORE_FIXED else 2
-    name = "Banana" if FIRST_BEFORE_FIXED else "Pineapple"
     assert result.errors is None
     assert result.data == {
         query_attr: {
             "edges": [
                 {
-                    "cursor": to_base64("arrayconnection", str(index)),
+                    "cursor": to_base64("arrayconnection", "0"),
                     "node": {
-                        "id": to_base64("Fruit", index + 1),
+                        "id": to_base64("Fruit", 1),
                         "color": "yellow",
-                        "name": name,
+                        "name": "Banana",
                     },
                 },
             ],
             "pageInfo": {
                 "hasNextPage": True,
-                "hasPreviousPage": not FIRST_BEFORE_FIXED,
-                "startCursor": to_base64("arrayconnection", str(index)),
-                "endCursor": to_base64("arrayconnection", str(index)),
+                "hasPreviousPage": False,
+                "startCursor": to_base64("arrayconnection", "0"),
+                "endCursor": to_base64("arrayconnection", "0"),
             },
         },
     }

--- a/tests/relay/test_fields.py
+++ b/tests/relay/test_fields.py
@@ -1,10 +1,17 @@
+from importlib.metadata import version
+
 import pytest
+from packaging.version import Version
 from pytest_django import DjangoAssertNumQueries
 from strawberry.relay.utils import to_base64
 
 from .schema import FruitModel, schema
 
 pytestmark = pytest.mark.usefixtures("_fixtures")
+
+# Strawberry 0.322.2 corrected first+before to select from the start of the
+# bounded connection. Keep coverage for the older supported releases as well.
+FIRST_BEFORE_FIXED = Version(version("strawberry-graphql")) >= Version("0.322.2")
 
 
 @pytest.fixture
@@ -705,24 +712,26 @@ def test_query_connection_filtering_first_with_before(query_attr: str):
         fruits_query.format(query_attr),
         variable_values={"first": 1, "before": to_base64("arrayconnection", "3")},
     )
+    index = 0 if FIRST_BEFORE_FIXED else 2
+    name = "Banana" if FIRST_BEFORE_FIXED else "Pineapple"
     assert result.errors is None
     assert result.data == {
         query_attr: {
             "edges": [
                 {
-                    "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+                    "cursor": to_base64("arrayconnection", str(index)),
                     "node": {
-                        "id": to_base64("Fruit", 3),
+                        "id": to_base64("Fruit", index + 1),
                         "color": "yellow",
-                        "name": "Pineapple",
+                        "name": name,
                     },
                 },
             ],
             "pageInfo": {
                 "hasNextPage": True,
-                "hasPreviousPage": True,
-                "startCursor": to_base64("arrayconnection", "2"),
-                "endCursor": to_base64("arrayconnection", "2"),
+                "hasPreviousPage": not FIRST_BEFORE_FIXED,
+                "startCursor": to_base64("arrayconnection", str(index)),
+                "endCursor": to_base64("arrayconnection", str(index)),
             },
         },
     }
@@ -734,24 +743,26 @@ async def test_query_connection_filtering_first_with_before_async(query_attr: st
         fruits_query.format(query_attr),
         variable_values={"first": 1, "before": to_base64("arrayconnection", "3")},
     )
+    index = 0 if FIRST_BEFORE_FIXED else 2
+    name = "Banana" if FIRST_BEFORE_FIXED else "Pineapple"
     assert result.errors is None
     assert result.data == {
         query_attr: {
             "edges": [
                 {
-                    "cursor": "YXJyYXljb25uZWN0aW9uOjI=",
+                    "cursor": to_base64("arrayconnection", str(index)),
                     "node": {
-                        "id": to_base64("Fruit", 3),
+                        "id": to_base64("Fruit", index + 1),
                         "color": "yellow",
-                        "name": "Pineapple",
+                        "name": name,
                     },
                 },
             ],
             "pageInfo": {
                 "hasNextPage": True,
-                "hasPreviousPage": True,
-                "startCursor": to_base64("arrayconnection", "2"),
-                "endCursor": to_base64("arrayconnection", "2"),
+                "hasPreviousPage": not FIRST_BEFORE_FIXED,
+                "startCursor": to_base64("arrayconnection", str(index)),
+                "endCursor": to_base64("arrayconnection", str(index)),
             },
         },
     }

--- a/tests/relay/test_prefetched_thread_hops.py
+++ b/tests/relay/test_prefetched_thread_hops.py
@@ -47,7 +47,7 @@ class ListConnectionQuery:
 
 
 list_connection_schema = strawberry.Schema(
-    query=ListConnectionQuery, extensions=[DjangoOptimizerExtension()]
+    query=ListConnectionQuery, extensions=[DjangoOptimizerExtension]
 )
 
 
@@ -122,7 +122,7 @@ class DbTouchingQuery:
 
 
 db_touching_schema = strawberry.Schema(
-    query=DbTouchingQuery, extensions=[DjangoOptimizerExtension()]
+    query=DbTouchingQuery, extensions=[DjangoOptimizerExtension]
 )
 
 

--- a/tests/test_custom_connection.py
+++ b/tests/test_custom_connection.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from functools import partial
 from typing import Any
 
 import pytest
@@ -147,7 +148,10 @@ def test_fragment_with_standard_connection_no_n1(enable_only_optimization: bool)
     standard_schema = strawberry.Schema(
         query=StandardQuery,
         extensions=[
-            DjangoOptimizerExtension(enable_only_optimization=enable_only_optimization)
+            partial(
+                DjangoOptimizerExtension,
+                enable_only_optimization=enable_only_optimization,
+            )
         ],
     )
 
@@ -243,7 +247,10 @@ def test_fragment_with_custom_connection_no_n1(enable_only_optimization: bool):
     schema = strawberry.Schema(
         query=Query,
         extensions=[
-            DjangoOptimizerExtension(enable_only_optimization=enable_only_optimization)
+            partial(
+                DjangoOptimizerExtension,
+                enable_only_optimization=enable_only_optimization,
+            )
         ],
     )
 

--- a/tests/test_field_permissions.py
+++ b/tests/test_field_permissions.py
@@ -109,7 +109,7 @@ async def test_with_async_permission_and_optimizer(db):
 
     schema = strawberry.Schema(
         query=Query,
-        extensions=[DjangoOptimizerExtension()],
+        extensions=[DjangoOptimizerExtension],
     )
     query = """
         query {
@@ -240,7 +240,7 @@ def test_with_sync_permission_and_optimizer(db):
 
     schema = strawberry.Schema(
         query=Query,
-        extensions=[DjangoOptimizerExtension()],
+        extensions=[DjangoOptimizerExtension],
     )
     query = """
         query {

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -293,11 +293,14 @@ def test_query_forward_with_interfaces(db, gql_client: GraphQLTestClient):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_query_forward_with_fragments(db, gql_client: GraphQLTestClient):
+@pytest.mark.parametrize("include_priority", [True, False])
+def test_query_forward_with_fragments(
+    db, gql_client: GraphQLTestClient, include_priority: bool
+):
     query = """
       fragment issueFrag on IssueType {
           nameWithKind
-          nameWithPriority
+          nameWithPriority @include(if: $includePriority)
       }
 
       fragment milestoneFrag on MilestoneType {
@@ -307,7 +310,7 @@ def test_query_forward_with_fragments(db, gql_client: GraphQLTestClient):
         }
       }
 
-      query TestQuery {
+      query TestQuery($includePriority: Boolean!) {
         issueConn {
           totalCount
           edges {
@@ -351,8 +354,12 @@ def test_query_forward_with_fragments(db, gql_client: GraphQLTestClient):
                     },
                 )
 
+    if not include_priority:
+        for issue in expected:
+            del issue["nameWithPriority"]
+
     with assert_num_queries(1 if DjangoOptimizerExtension.enabled.get() else 56):
-        res = gql_client.query(query)
+        res = gql_client.query(query, {"includePriority": include_priority})
 
     assert res.data == {
         "issueConn": {

--- a/tests/test_paginated_type.py
+++ b/tests/test_paginated_type.py
@@ -1364,7 +1364,7 @@ def test_offset_paginated_runs_perms_optimizer_and_type_hook_once(mocker):
     perms_spy = mocker.spy(field_mod, "filter_with_perms")
     optimize_spy = mocker.spy(DjangoOptimizerExtension, "optimize")
 
-    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension()])
+    schema = strawberry.Schema(query=Query, extensions=[DjangoOptimizerExtension])
     models.Fruit.objects.create(name="Apple")
 
     res = schema.execute_sync(

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -16,6 +16,7 @@ from strawberry.types.base import WithStrawberryObjectDefinition
 import strawberry_django
 from strawberry_django.fields.field import StrawberryDjangoField
 from strawberry_django.settings import StrawberryDjangoSettings
+from strawberry_django.utils import IS_GQL_32
 
 from . import models, utils
 
@@ -134,9 +135,11 @@ async def test_required_pk_single(query, users):
     assert bool(result.errors)
     assert len(result.errors) == 1
     assert isinstance(result.errors[0], GraphQLError)
-    assert (
-        result.errors[0].message == "Field 'user' argument 'pk' of type 'ID!' is "
-        "required, but it was not provided."
+    argument = (
+        "Field 'user' argument 'pk'" if IS_GQL_32 else "Argument 'Query.user(pk:)'"
+    )
+    assert result.errors[0].message == (
+        f"{argument} of type 'ID!' is required, but it was not provided."
     )
 
 
@@ -155,9 +158,11 @@ async def test_required_id_as_pk_single(query_id_as_pk, users):
     assert bool(result.errors)
     assert len(result.errors) == 1
     assert isinstance(result.errors[0], GraphQLError)
-    assert (
-        result.errors[0].message == "Field 'user' argument 'id' of type 'ID!' is "
-        "required, but it was not provided."
+    argument = (
+        "Field 'user' argument 'id'" if IS_GQL_32 else "Argument 'Query.user(id:)'"
+    )
+    assert result.errors[0].message == (
+        f"{argument} of type 'ID!' is required, but it was not provided."
     )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,7 +37,7 @@ def generate_query(query=None, mutation=None, enable_optimizer=False):
     extensions = []
 
     if enable_optimizer:
-        extensions = [DjangoOptimizerExtension()]
+        extensions = [DjangoOptimizerExtension]
     schema = strawberry.Schema(query=query, mutation=mutation, extensions=extensions)
 
     def process_result(result):

--- a/uv.lock
+++ b/uv.lock
@@ -156,14 +156,14 @@ toml = [
 
 [[package]]
 name = "cross-web"
-version = "0.4.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/4f/bdb62e969649ee76d4741ef8eee34384ec2bc21cc66eb7fd244e6ad62be8/cross_web-0.4.0.tar.gz", hash = "sha256:4ae65619ddfcd06d6803432c0366342d7e8aeba10194b4e144d73a662e75370c", size = 157111, upload-time = "2025-12-25T20:45:21.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/a0/bdb8370215987cc5bde497cb8b976b17ab14841566ecef2aab6ae3e6c7b0/cross_web-0.7.0.tar.gz", hash = "sha256:15fbc8b9a824a055db8127fd6e43e0773074f620fdecb6b2b587d3d0a2bdd459", size = 332407, upload-time = "2026-05-19T14:18:48.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/d6/6c6a036655e5091b26b9f350dcf43821895325aa4727396b14c67679a957/cross_web-0.4.0-py3-none-any.whl", hash = "sha256:0c675bd26e91428cab31e3e927929b42da94aa96da92974e57c78f9a732d0e9b", size = 14200, upload-time = "2025-12-25T20:45:23.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4a/78b52ec2edcbd9b123638f4e0421fd8699ebe653ebf63ac5f82abd2665bc/cross_web-0.7.0-py3-none-any.whl", hash = "sha256:ddea9be3c68b48eaf16561847a5831a559786949c544b3701432e00a4e8d19d9", size = 25207, upload-time = "2026-05-19T14:18:47.614Z" },
 ]
 
 [[package]]
@@ -174,9 +174,9 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "asgiref" },
-    { name = "sqlparse" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "asgiref", marker = "python_full_version < '3.12'" },
+    { name = "sqlparse", marker = "python_full_version < '3.12'" },
+    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/1c/188ce85ee380f714b704283013434976df8d3a2df8e735221a02605b6794/django-5.2.9.tar.gz", hash = "sha256:16b5ccfc5e8c27e6c0561af551d2ea32852d7352c67d452ae3e76b4f6b2ca495", size = 10848762, upload-time = "2025-12-02T14:01:08.418Z" }
 wheels = [
@@ -191,9 +191,9 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "asgiref" },
-    { name = "sqlparse" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "asgiref", marker = "python_full_version >= '3.12'" },
+    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
+    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/75/19762bfc4ea556c303d9af8e36f0cd910ab17dff6c8774644314427a2120/django-6.0.tar.gz", hash = "sha256:7b0c1f50c0759bbe6331c6a39c89ae022a84672674aeda908784617ef47d8e26", size = 10932418, upload-time = "2025-12-03T16:26:21.878Z" }
 wheels = [
@@ -301,7 +301,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -732,7 +732,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.310.1"
+version = "0.322.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cross-web" },
@@ -741,9 +741,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/65/8fc31347cd1a2809ea72ec4c354fc6996c79f64f0cd84df9707117045d2e/strawberry_graphql-0.310.1.tar.gz", hash = "sha256:bd01edc3016d8caea543dc8a1d2394d5257a87a36e9fbe8c3aedeeda7c2c8ec1", size = 211966, upload-time = "2026-03-08T14:00:46.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/8e/268b99664efc125ebe7a7ee0bcdb479a5a931d3a8cf6c24aecfb434aca5c/strawberry_graphql-0.322.2.tar.gz", hash = "sha256:d0040b690777b0e8f375341794576ccb964fcaf90fdecdc3ca5e873bea554841", size = 233734, upload-time = "2026-07-20T20:47:01.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/f7/90f885565fb3fbc44c54bda17dd4c36a5c6d9b84ecfa7a6d49d30084cab3/strawberry_graphql-0.310.1-py3-none-any.whl", hash = "sha256:d6da1f16cab2b9cb4a9d5e0c196a33f98f76157d559e5afbb48e81348db163d0", size = 309316, upload-time = "2026-03-08T14:00:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/548da181af07af86f4c61c2556de1254700f8101a13019e4fd2f8b8ce8ff/strawberry_graphql-0.322.2-py3-none-any.whl", hash = "sha256:37047d2f801b4b0d22465d31d3cb4ed48a0592bca5941aeeb3adba995bd668f0", size = 337228, upload-time = "2026-07-20T20:46:59.296Z" },
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ requires-dist = [
     { name = "django-choices-field", marker = "extra == 'enum'", specifier = ">=2.2.2" },
     { name = "django-debug-toolbar", marker = "extra == 'debug-toolbar'", specifier = ">=6.0.0" },
     { name = "django-polymorphic", marker = "extra == 'polymorphic'", specifier = ">=4.0.0" },
-    { name = "strawberry-graphql", specifier = ">=0.310.1" },
+    { name = "strawberry-graphql", specifier = ">=0.322.2" },
 ]
 provides-extras = ["debug-toolbar", "enum", "polymorphic"]
 


### PR DESCRIPTION
Require Strawberry GraphQL 0.322.2 or newer and update the Relay tests to assert its corrected `first` + `before` pagination behavior. Remove version-dependent expectations, refresh the lockfile to the new minimum, and register schema extensions as classes or factories to match Strawberry's supported API.

Keep project-schema comparisons independent of top-level definition ordering while retaining checks for fields, arguments, descriptions, directive applications, and duplicate definitions. The stored snapshot is unchanged.

Update the GraphQL-core 3.3 CI pin from 3.3.0a12 to 3.3.0rc0, which provides the enum coercion API required by newer Strawberry. Adapt the query optimizer to preserve resolve-info context and pass fragment and variable values in the formats expected by GraphQL-core 3.3. Cover variables inside named fragments, including query counts, and update two assertions for the changed required-argument error wording.

Include a minor release note for the new Strawberry requirement and GraphQL-core compatibility changes. This addresses the stale expectations reported by Strawberry's [downstream compatibility job](https://github.com/strawberry-graphql/strawberry/actions/runs/34154695036/job/101843982903?pr=4618).

Validation on Python 3.14.3 / Django 6.0:
- Strawberry 0.322.2 with GraphQL-core 3.2.7 and 3.3.0rc0: full suite passed on each (1,243 passed, 11 skipped), then the expanded fragment regression passed all 8 cases on each.
- Strawberry 0.327.7 with GraphQL-core 3.3.0rc0: 1,247 passed, 11 skipped, including the expanded regression.
- Full repository Pyright with locked dependencies: 0 errors and 0 warnings.
- Formatting and whitespace checks pass. Lint passes for changed code; the existing ERA001 examples in optimizer.py and RUF076 fixture in tests/conftest.py remain unchanged.
